### PR TITLE
[codex] Preserve GL raw payload exports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,14 @@ on:
 jobs:
   validate:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version:
+          - "3.10"
+          - "3.11"
+          - "3.12"
+          - "3.13"
 
     steps:
       - name: Check out repository
@@ -19,7 +27,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: ${{ matrix.python-version }}
 
       - name: Set up uv
         uses: astral-sh/setup-uv@v4

--- a/README.en.md
+++ b/README.en.md
@@ -88,20 +88,20 @@ python -m ba_downloader sync --region jp
 ## **Basic Parameters**
 **`*`** : **required option**
 
-| Parameter                  | Short Form | Description                                                                    | Default            | Example                       |
-| -------------------------- | ---------- | ------------------------------------------------------------------------------ | ------------------ | ----------------------------- |
-| **`--region`**`*`          | `-r`       | **Server region**: `cn` (China), `gl` (Global), `jp` (Japan)                   | None               | `-r jp`                       |
-| `--threads`                | `-t`       | **Number of concurrent download or extraction workers**                        | `20`               | `-t 50`                       |
-| `--version`                | `-v`       | **Resource version to download** (currently effective for GL only)             | None               | `-v 1.2.3`                    |
-| `--platform`               | `-p`       | **Resource platform**: `windows`, `android`, `ios` (effective for JP only)     | `android`          | `-p windows`                  |
-| `--raw-dir`                | `-rd`      | **Directory for raw downloaded files**                                         | `"RawData"`        | `-rd raw_folder`              |
-| `--extract-dir`            | `-ed`      | **Directory for extracted output**                                             | `"Extracted"`      | `-ed output_folder`           |
-| `--temp-dir`               | `-td`      | **Directory for temporary files**                                              | `"Temp"`           | `-td temp_dir`                |
-| `--extract-while-download` | `-ewd`     | **Extract files while downloading** (available only for `sync`; use carefully for large resource sets) | `False`            | `--extract-while-download`    |
-| `--resource-type`          | `-rt`      | **Resource types**: `table`, `media`, `bundle`, `all`                          | `all`              | `--resource-type media table` |
-| `--proxy`                  | `-px`      | **HTTP proxy**                                                                 | None (system proxy) | `-px http://127.0.0.1:8080`   |
-| `--max-retries`            | `-mr`      | **Maximum retry count for failed downloads**                                   | `5`                | `--max-retries 3`             |
-| `--search`                 | `-s`       | **Basic search**: keywords used to filter files for download (`sync` and `download` only) |
+| Parameter                  | Short Form | Description                                                                                                                   | Default             | Example                       |
+| -------------------------- | ---------- | ----------------------------------------------------------------------------------------------------------------------------- | ------------------- | ----------------------------- |
+| **`--region`**`*`          | `-r`       | **Server region**: `cn` (China), `gl` (Global), `jp` (Japan)                                                                  | None                | `-r jp`                       |
+| `--threads`                | `-t`       | **Number of concurrent download or extraction workers**                                                                       | `20`                | `-t 50`                       |
+| `--version`                | `-v`       | **Resource version to download** (currently effective for GL only)                                                            | None                | `-v 1.2.3`                    |
+| `--platform`               | `-p`       | **Resource platform**: `windows`, `android`, `ios` (effective for JP only)                                                    | `android`           | `-p windows`                  |
+| `--raw-dir`                | `-rd`      | **Directory for raw downloaded files**                                                                                        | `"RawData"`         | `-rd raw_folder`              |
+| `--extract-dir`            | `-ed`      | **Directory for extracted output**                                                                                            | `"Extracted"`       | `-ed output_folder`           |
+| `--temp-dir`               | `-td`      | **Directory for temporary files**                                                                                             | `"Temp"`            | `-td temp_dir`                |
+| `--extract-while-download` | `-ewd`     | **Extract files while downloading** (available only for `sync`; use carefully for large resource sets)                        | `False`             | `--extract-while-download`    |
+| `--resource-type`          | `-rt`      | **Resource types**: `table`, `media`, `bundle`, `all`                                                                         | `all`               | `--resource-type media table` |
+| `--proxy`                  | `-px`      | **HTTP proxy**                                                                                                                | None (system proxy) | `-px http://127.0.0.1:8080`   |
+| `--max-retries`            | `-mr`      | **Maximum retry count for failed downloads**                                                                                  | `5`                 | `--max-retries 3`             |
+| `--search`                 | `-s`       | **Basic search**: keywords used to filter files for download (`sync` and `download` only)                                     |
 | `--advanced-search`        | `-as`      | **Advanced search**: character-oriented filters (`sync` only; currently supported by GL only and requires a .NET environment) |
 
 **(Advanced search is currently unsupported on CN) Supported advanced-search fields:**

--- a/agents.md
+++ b/agents.md
@@ -1,156 +1,22 @@
-## 0. 角色
+## Role and Constraints
+- You are a Python/CLI and decompilation engineer, maintaining a multi-region resource downloading and extraction tool.
+- All code must be written in English: naming, comments, errors, CLI help, and example commands.
+- Documentation may be written in Chinese.
 
-1. **你是一个 Python / CLI 工程师**，负责维护一个基于 Python 的多区服资源下载与提取工具。
-2. **所有代码必须使用英文**
-3. **文档可以使用中文**，但示例代码与命令必须是英文。
+## Workflow
+- Read relevant files/documents first, then provide a brief plan in Chinese with 3–6 bullet points.
+- During implementation, keep the code style in English and prioritize reusing existing models, ports, boundaries, and project style.
+- After completion, run necessary formatting, type checks, and high-value tests.
+- The summary must explain what was changed, which scenarios are affected, and whether there are compatibility risks.
 
+## Code and Compatibility
+- Use type hints and prioritize readability; error handling must be traceable and actionable.
+- Avoid import-time side effects, scattered magic values, and direct coupling to implementation details.
+- Do not casually rename, remove, or change existing parameters; when modifying user-visible behavior, update `--help` and `README.md` accordingly.
+- Incompatible changes are allowed by default, but the impact scope, migration method, and risks must be explained in advance.
+- CLI entry points, command names, and core parameters are considered stable APIs and must be changed cautiously.
+- When uncertain, you must ask the user; if confirmation is unavailable, stop the conversation.
 
-
-## 1. 项目结构速览
-
-当前项目采用 `src/ba_downloader` 包结构：
-
-- `src/ba_downloader/cli`
-  - CLI 参数解析与命令分发
-- `src/ba_downloader/application`
-  - 用例编排与服务层
-- `src/ba_downloader/domain`
-  - 模型、接口、异常、领域服务
-- `src/ba_downloader/infrastructure`
-  - 具体实现：providers、extractors、logging、http、tools、storage 等
-- `src/ba_downloader/shared`
-  - 纯工具模块；当前主要保留跨模块复用且无状态的能力
-- `src/ba_downloader/legacy`
-  - 迁移兼容层；仅在当前重构阶段保留，避免继续扩散依赖
-
-顶层辅助目录：
-
-- `tests/`
-- `scripts/`
-
-## 2. 项目事实
-
-修改代码时，应默认以下前提成立：
-
-- **运行环境**
-  - Python 版本：`>= 3.10`
-  - `.NET 8 SDK`：用于 table 提取与高级检索相关流程
-- **默认输出目录（可通过参数覆盖）**
-  - `Temp/`、`RawData/`、`Extracted/` 为逻辑目录名
-  - 未显式指定时会自动加区服前缀，例如 `CNRawData`
-  - `Extracted/FlatData` 与 `Extracted/Dumps` 为 Flatbuffer dump / compile 的产物
-  - 角色关系文件为 `{REGION}CharacterRelation.json`，默认输出在工作目录
-- **CLI 入口**
-- **命令名**
-- **核心 CLI 参数**
-
-> 对这些名称和整体语义，要**谨慎地改动**，并做好兼容层或迁移说明，除非有明确指示可进行破坏性更改。
-
-## 4. 语言与风格要求
-
-### 4.1 代码必须使用英文
-
-在任何代码文件中，以下内容必须全部使用英文：
-
-- 变量名、函数名、类名、模块名、注释
-- 异常信息与错误提示
-- 命令行帮助文本与参数说明
-
-### 4.2 文档可以使用中文
-
-- `README.md`、`agents.md`、其他说明文档可以使用中文叙述。
-- 但文档中的 **代码块** 仍须保持英文（包括注释和命令）。
-- 如需解释特定英文名词，可在文档正文中用中文说明。
-
-## 5. 代理工作流
-
-当你收到在本仓库中的任务请求时，请按照以下顺序工作：
-
-1. **获取上下文**
-2. 
-   - 若任务提到其他文档，优先打开对应文件。
-   - 如果任务提到具体文件或模块，先快速浏览这些文件。
-
-3. **给出「简短计划」**
-
-   - 用 3～6 条中文要点描述你准备做什么：
-     - 会修改哪些文件
-     - 预期新增或调整的功能点
-     - 是否会引入新的依赖或 CLI 参数
-
-4. **实施修改**
-
-   - 代码实现时保持英文风格与项目现有风格一致。
-
-5. **验证**
-
-   - 执行格式化、类型检查、测试用例。
-
-6. **总结**
-
-   - 用中文总结本次修改的效果：
-     - 改了什么
-     - 会影响哪些用户场景
-     - 有无潜在的行为改变或兼容性风险
-
-## 6. 关于兼容性
-
-处理相关需求时，要遵守：
-
-1. **参数名视为 API**
-   - 不要随意重命名、删除已有参数，除非用户明确指示
-
-
-2. **帮助与文档同步**
-
-   - 当你修改参数行为或新增选项时，同步更新：
-     - CLI `--help` 输出
-     - `README.md` 中的参数说明与使用示例
-     - 必要时更新 `agents.md` 中的相关约束
-
-## 7. 修改代码时的具体技术规范
-
-### 7.1 Python 代码
-
-- 代码使用类型标注（type hints）。
-- 优先保证**可读性**。
-- 当某个错误在根本上具有问题时，考虑向用户确认重构。
-- 错误处理应可操作、可定位。
-- 使用配置表、映射或 registry 来集中管理区服差异。
-
-### 7.2 可维护性与最佳实践
-
-- 保持依赖方向清晰：
-- 新增逻辑时优先复用已有模型和 port，不要绕过现有边界直接耦合实现细节。
-- 避免 import-time side effect。
-- 避免协议字段名、区服常量、路径前缀、正则模式等魔法值散落。
-- 如需新增第三方依赖：
-  - 先确认没有更轻量的替代方案。
-  - 必须同步更新依赖定义文件。
-- 修改用户可见行为时，优先同步：
-  - CLI `--help`
-  - `README.md`
-  - 必要时的 `agents.md`
-
-## 8. 测试与验证要求
-
-在你完成较大改动后，应至少提供以下验证流程：
-
-- 优先编写**高价值测试**，不要写低价值测试。
-- 如果某处改动**无法写出有实际约束力的测试**，不要强行补无意义单测。
-- 测试应尽量能够回答实际存在的问题。
-- 若改动涉及 CLI 或真实资源链路，额外给出至少一条用户视角命令，例如：
-
-```bash
-ba-downloader download --region cn --threads 4
-```
-
-
-## 9. 当你不确定时
-
-- 对行为是否符合用户需求拿不准
-
-请遵循以下优先级：
-1. 中断操作向 User 进行询问。
-2. **倾向于不改变现有行为**，避免 silent breaking change。
-3. 在提交说明或总结中，指出存在的潜在不确定性，并给出你做的保守选择。
+## Commit messages
+- Use Conventional Commits: `type(scope): concise summary`.
+- Allowed types: `feat`, `fix`, `refactor`, `chore`, `docs`, `test`, `style`, `perf`, `ci`.

--- a/docs/development.md
+++ b/docs/development.md
@@ -51,7 +51,7 @@ powershell -ExecutionPolicy Bypass -File scripts/run-preflight.ps1
 当前 dumper backend 策略：
 
 - `jp`：默认使用 `cpp2il_custom`
-- `gl`：保持使用 legacy `Il2CppDumper`
+- `gl`：默认使用 `cpp2il_custom`
 - `cn`：内部使用 metadata-only `cn_metadata_exporter` backend（当前尚未对用户开放）
 
 如果以源码方式运行并希望固定 Cpp2IL 依赖，请使用子模块：
@@ -74,6 +74,12 @@ CN metadata backend 额外依赖仓库内 vendored 的独立 dumper 工程：
 ```shell
 dotnet build third_party/cn_metadata_exporter/cn_metadata_exporter.csproj -c Release
 ```
+
+## GL 特殊 payload 备注
+
+GL `Table/` 中的 `eliminateRaid` payload 当前已经支持 raw 导出，但尚未实现语义解析。专项分析记录见：
+
+- `docs/gl-eliminate-raid.md`
 
 ## 分支与发版
 

--- a/docs/gl-eliminate-raid.md
+++ b/docs/gl-eliminate-raid.md
@@ -1,0 +1,249 @@
+# GL eliminateRaid 分析记录
+
+本文档记录当前对 GL `eliminateRaid` payload 的分析结论、已确认事实和后续导出方案。
+
+## 1. 范围
+
+当前讨论对象为 GL `Table/` 中命名包含 `eliminateRaid` 的 zip，例如：
+
+- `6012301_eliminateRaid_binah_outdoor_unarmed_normal.zip`
+- `6012301_eliminateRaid_binah_outdoor_unarmed_normal_start2phase.zip`
+- `6012301_eliminateRaid_binah_outdoor_unarmed_normal_start3phase.zip`
+- `6062106_eliminateRaid_perorozilla_outdoor_light_insane_start2phase.zip`
+
+这些 zip 当前已经可以被稳定提取，但只会导出 raw `.bytes`，不会输出最终语义 JSON。
+
+## 2. 当前提取行为
+
+当前 `extract -r gl -rt table` 会对 `*eliminateRaid*.zip` 走独立路由：
+
+- 正常打开 zip
+- 提取内层 `.bytes`
+- 直接落盘 raw payload
+- 输出一条 `INFO`，提示 semantic parser is not implemented yet
+
+这属于预期行为，不是错误。
+
+## 3. 已确认事实
+
+### 3.1 它不是当前 FlatData 表
+
+这批 payload 不是当前 `FlatData` 生成类，也不是 `GroundGridFlat` / `GroundNodeLayerFlat` 这类地图网格表。
+
+继续按文件名猜 `FlatData` schema，会得到错误的：
+
+```text
+generated FlatData class is missing
+```
+
+### 3.2 头部有稳定结构
+
+以样本：
+
+- `GL_Extracted/Table/6012301_eliminateRaid_binah_outdoor_unarmed_normal_start2phase/6012301_eliminateraid_binah_outdoor_unarmed_normal_start2phase.bytes`
+
+为例，其头部可以观察到：
+
+- 前导 signed marker：`-1274`
+- 一个短长度值：`4`
+- 版本字符串：`"1.82"`
+
+样本开头片段如下：
+
+```text
+06 fb ff ff ff 04 00 00 00 31 2e 38 32 ...
+```
+
+同组样本 `normal / start2phase / start3phase` 具有相同格式，仅内容数量不同。
+
+### 3.3 payload 内有显式长度前缀字符串
+
+同一条样本中可以稳定读到：
+
+- `SpawnPlayer`
+- `SetImmuneOff_2 (1)`
+- `EndBattle`
+- `SpawnBinah`
+- `1-bPhaseChanged`
+- `SpawnPointParent`
+- `Binah_Outdoor_Unarmed_Normal`
+
+其中 `SpawnPlayer` 不是偶然扫出来的 ASCII，而是带有显式长度字段的字符串值。
+
+例如这段记录：
+
+```text
+04 f4 ff ff ff 0b 00 00 00 53 70 61 77 6e 50 6c 61 79 65 72
+```
+
+可以稳定拆成：
+
+- `0x04`：1-byte tag
+- `0xfffffff4`：signed value `-12`
+- `0x0000000b`：长度 `11`
+- `"SpawnPlayer"`
+
+### 3.4 这批内容更像 battle / raid command script
+
+对多条样本扫描 ASCII 后，可以看到大量高价值名称：
+
+- `SpawnPlayer`
+- `EndBattle`
+- `SpawnBinah`
+- `CommandSpawnBinah`
+- `SetImmuneOff`
+- `SetImmuneOff_2`
+- `0->1PhaseChanged`
+- `0->2PhaseChanged`
+- `Moveto4Section`
+- `Common_Sandbag`
+- `Common_Barrel`
+- `Common_Baricade`
+- `Desert_Truck_Low`
+
+这说明 payload 同时包含：
+
+- 指令名
+- 条件或状态名
+- 场景对象名
+- 阶段切换信息
+
+### 3.5 dump.cs 中存在高度相关的 runtime 类型
+
+在 `GL_Extracted/Dumps/dump.cs` 中可以确认存在大量同一生态的类型，并且很多是 `MemoryPack.IMemoryPackable`：
+
+- `GroundCommandSpawnPlayer`
+- `GroundCommandEndBattle`
+- `GroundCommandDestroyObstacle`
+- `GroundCommandSetStatusImmune`
+- `GroundCommandSpawnEntity`
+- `GroundCommandStartSection`
+- `GroundConditionCharacterPhaseChanged`
+- `GroundConditionObstacleDestroyed`
+
+同时还能看到对应的 visual 类：
+
+- `GroundCommandSpawnPlayerVisual`
+- `GroundCommandEndBattleVisual`
+- `GroundCommandDestroyObstacleVisual`
+- `GroundCommandForceUpdateRaidBossIndexVisual`
+
+这说明 GL 运行时确实存在一整套 `GroundCommand* / GroundCondition*` 体系。
+
+## 4. 当前可以确认的结论
+
+高置信度结论：
+
+- `eliminateRaid` 是结构化二进制，不是随机垃圾数据。
+- `eliminateRaid` 不是当前 `FlatData` 表。
+- `SpawnPlayer`、`EndBattle` 等更像 runtime command 名，而不是插件名。
+- 这批内容与 `MX.Logic.Battles.GroundCommand* / GroundCondition*` 体系强相关。
+
+当前不能过度声称的内容：
+
+- 不能直接断言整个外层容器就是“标准 MemoryPack 文件”。
+- 不能断言所有负数 tag 的精确语义已经完全明确。
+- 不能保证每一条字符串都直接一一映射到 `dump.cs` 中的具体类型。
+
+## 5. 推荐导出方案
+
+不要直接尝试一步到位生成最终语义 JSON。更稳的方案是分两层推进。
+
+### 5.1 第一阶段：Inspect JSON
+
+目标是保留 raw payload，同时导出一个半结构化的可读分析文件。
+
+推荐输出格式：
+
+```json
+{
+  "format": "gl-eliminate-raid-inspect-v1",
+  "header": {
+    "sentinel": -1274,
+    "version": "1.82",
+    "record_count_hint": 3
+  },
+  "tokens": [
+    {
+      "offset": 30,
+      "tag": 4,
+      "signed_value": -12,
+      "string": "SpawnPlayer"
+    },
+    {
+      "offset": 170,
+      "tag": 4,
+      "signed_value": -19,
+      "string": "SetImmuneOff_2 (1)"
+    },
+    {
+      "offset": 292,
+      "tag": 4,
+      "signed_value": -10,
+      "string": "EndBattle"
+    }
+  ],
+  "ascii_strings": [
+    "SpawnBinah",
+    "Binah_Outdoor_Unarmed_Normal",
+    "SpawnPointParent",
+    "Common_Sandbag"
+  ]
+}
+```
+
+这个阶段的目标不是“最终正确语义”，而是：
+
+- 可读
+- 可 diff
+- 可对齐不同 phase 的差异
+- 不因为局部未知字段而丢失整条记录
+
+### 5.2 第二阶段：Typed JSON
+
+在 Inspect JSON 稳定后，再引入命令名到类型名的映射，例如：
+
+- `SpawnPlayer -> GroundCommandSpawnPlayer`
+- `EndBattle -> GroundCommandEndBattle`
+- `DestroyObstacle -> GroundCommandDestroyObstacle`
+- `SetImmuneOff* -> GroundCommandSetStatusImmune`
+- `*PhaseChanged -> GroundConditionCharacterPhaseChanged` 或相关 condition
+
+Typed JSON 阶段建议保留以下兜底字段：
+
+- `raw_hex`
+- `raw_size`
+- `unknown_fields`
+- `unresolved_type`
+
+这样即使某些命令尚未完全逆出，也不会导致整条脚本导出失败。
+
+## 6. 当前不建议做的事情
+
+- 不要把 `eliminateRaid` 强行塞进 `GroundGridFlat`。
+- 不要继续按 zip 文件名去猜 `FlatData` schema。
+- 不要在证据不足时直接宣称“这就是标准 MemoryPack 文件”。
+
+## 7. 建议的下一步
+
+如果后续要继续推进，建议按这个顺序：
+
+1. 先做 `Inspect JSON` 导出，不改 raw 导出。
+2. 选一组同 boss、不同 phase 的样本对齐：
+   - `normal`
+   - `start2phase`
+   - `start3phase`
+3. 先建立 token / string / offset 层面的稳定规则。
+4. 再尝试把已知命令映射到 `GroundCommand* / GroundCondition*` 类型。
+
+当前最适合做第一组建模样本的是：
+
+- `6012301_eliminateRaid_binah_outdoor_unarmed_normal`
+- `6012301_eliminateRaid_binah_outdoor_unarmed_normal_start2phase`
+- `6012301_eliminateRaid_binah_outdoor_unarmed_normal_start3phase`
+
+因为它们：
+
+- 结构一致
+- 内容差异清晰
+- 字符串可读性较高

--- a/src/ba_downloader/cli/main.py
+++ b/src/ba_downloader/cli/main.py
@@ -49,9 +49,33 @@ def _add_common_options(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--region", "-r", choices=["cn", "gl", "jp"], required=True)
     parser.add_argument("--threads", "-t", type=int, default=20)
     parser.add_argument("--version", "-v", default="")
-    parser.add_argument("--raw-dir", "-rd", default="RawData")
-    parser.add_argument("--extract-dir", "-ed", default="Extracted")
-    parser.add_argument("--temp-dir", "-td", default="Temp")
+    parser.add_argument(
+        "--raw-dir",
+        "-rd",
+        default="RawData",
+        help=(
+            "Raw asset directory. The default logical name is normalized by region "
+            "when unchanged."
+        ),
+    )
+    parser.add_argument(
+        "--extract-dir",
+        "-ed",
+        default="Extracted",
+        help=(
+            "Extracted asset directory. The default logical name is normalized by "
+            "region when unchanged."
+        ),
+    )
+    parser.add_argument(
+        "--temp-dir",
+        "-td",
+        default="Temp",
+        help=(
+            "Temporary asset directory. The default logical name is normalized by "
+            "region when unchanged."
+        ),
+    )
     parser.add_argument(
         "--resource-type",
         "-rt",

--- a/src/ba_downloader/domain/models/settings.py
+++ b/src/ba_downloader/domain/models/settings.py
@@ -46,12 +46,13 @@ class AppSettings:
             if temp_dir == "Temp":
                 temp_dir = f"{platform_prefix}{temp_dir}"
         else:
+            region_prefix = f"{region.upper()}_"
             if raw_dir == "RawData":
-                raw_dir = f"{region.upper()}{raw_dir}"
+                raw_dir = f"{region_prefix}{raw_dir}"
             if extract_dir == "Extracted":
-                extract_dir = f"{region.upper()}{extract_dir}"
+                extract_dir = f"{region_prefix}{extract_dir}"
             if temp_dir == "Temp":
-                temp_dir = f"{region.upper()}{temp_dir}"
+                temp_dir = f"{region_prefix}{temp_dir}"
 
         resource_type = tuple(r.lower() for r in self.resource_type)
         if not resource_type or "all" in resource_type:

--- a/src/ba_downloader/infrastructure/extractors/table.py
+++ b/src/ba_downloader/infrastructure/extractors/table.py
@@ -53,7 +53,42 @@ class ProcessedTableArtifact:
 
 class TableExtractor:
     GROUND_GRID_SCHEMA_NAME = "GroundGridFlat.bytes"
+    GROUND_NODE_LAYER_SCHEMA_NAME = "GroundNodeLayerFlat.bytes"
     RHYTHM_BEATMAP_ARCHIVE_NAME = "RhythmBeatmapData.zip"
+    GL_GROUND_ARCHIVE_PREFIXES = ("sb_", "rb_", "rd_", "db_", "c_sb_")
+    GL_C_SB_RAW_SCRIPT_KEYWORDS = (
+        "destroyhyakkiyakomatsuri",
+        "wildhuntstreet",
+        "expresstrain",
+        "hyakkiyakomatsuri",
+        "hyakkiyakomoviestreet",
+        "hyakkiyakonorthtown",
+    )
+    GL_RAW_SCRIPT_TEST_PREFIXES = (
+        "basementtest",
+        "character_resource_",
+        "charactertest",
+        "ch0265test",
+        "chesedscenariotest",
+        "combattest_",
+        "damagetest_",
+        "effectcountlimittest_",
+        "groundpassivetest",
+        "holdtest",
+        "hovercrafttest",
+        "hyakkiyako",
+        "newyearpathvisualtest",
+        "np186test",
+        "npctest",
+        "overridetest_",
+        "playground_obstacleset_",
+        "raidtest",
+    )
+    GL_RAW_SCRIPT_TEST_ARCHIVE_NAMES = (
+        "camerarotatetest.zip",
+        "changelooktargettest.zip",
+        "ch0265test2.zip",
+    )
 
     def __init__(
         self,
@@ -363,6 +398,66 @@ class TableExtractor:
         )
 
     @classmethod
+    def _is_gl_ground_archive(cls, file_name: str) -> bool:
+        archive_name = path.basename(file_name)
+        lower_name = archive_name.lower()
+        return lower_name.endswith(".zip") and lower_name.startswith(
+            cls.GL_GROUND_ARCHIVE_PREFIXES
+        )
+
+    @classmethod
+    def _is_gl_c_sb_raw_script_archive(cls, file_name: str) -> bool:
+        archive_name = path.basename(file_name).lower()
+        return archive_name.endswith(".zip") and archive_name.startswith(
+            "c_sb_"
+        ) and any(keyword in archive_name for keyword in cls.GL_C_SB_RAW_SCRIPT_KEYWORDS)
+
+    @classmethod
+    def _resolve_gl_ground_schema_name(cls, archive_name: str) -> str:
+        if "_nodelayer" in archive_name.lower():
+            return cls.GROUND_NODE_LAYER_SCHEMA_NAME
+        return cls.GROUND_GRID_SCHEMA_NAME
+
+    @staticmethod
+    def _is_gl_numeric_stage_archive(file_name: str) -> bool:
+        archive_name = path.basename(file_name).lower()
+        return (
+            archive_name.endswith(".zip")
+            and archive_name[:1].isdigit()
+            and "eliminateraid" not in archive_name
+        )
+
+    @staticmethod
+    def _is_gl_eliminate_raid_archive(file_name: str) -> bool:
+        archive_name = path.basename(file_name).lower()
+        return archive_name.endswith(".zip") and "eliminateraid" in archive_name
+
+    @staticmethod
+    def _is_gl_enemy_boss_script_archive(file_name: str) -> bool:
+        archive_name = path.basename(file_name).lower()
+        return (
+            archive_name.endswith(".zip")
+            and archive_name.startswith("en")
+            and len(archive_name) >= 6
+            and archive_name[2:6].isdigit()
+        )
+
+    @staticmethod
+    def _is_mgs_logic_ground_archive(file_name: str) -> bool:
+        return path.basename(file_name) == "MGSLogicGroundData.zip"
+
+    @classmethod
+    def _is_gl_raw_script_test_archive(cls, file_name: str) -> bool:
+        archive_name = path.basename(file_name).lower()
+        return (
+            archive_name.startswith(cls.GL_RAW_SCRIPT_TEST_PREFIXES)
+            or "obstest" in archive_name
+            or "timelinetest" in archive_name
+            or "emojitest" in archive_name
+            or archive_name in cls.GL_RAW_SCRIPT_TEST_ARCHIVE_NAMES
+        )
+
+    @classmethod
     def _is_rhythm_beatmap_archive(cls, file_name: str) -> bool:
         return path.basename(file_name) == cls.RHYTHM_BEATMAP_ARCHIVE_NAME
 
@@ -446,6 +541,64 @@ class TableExtractor:
                 )
             elif self._is_ground_stage_patch_archive(archive_name):
                 self._extract_ground_stage_patch_archive(
+                    file_name,
+                    warnings=warnings,
+                    should_stop=should_stop,
+                )
+            elif self._is_gl_c_sb_raw_script_archive(archive_name):
+                self._extract_raw_zip_archive(
+                    file_name,
+                    warnings=warnings,
+                    should_stop=should_stop,
+                    info_message=(
+                        f"Extracted raw GL C_sb script payloads from {archive_name}; "
+                        "semantic parser is not implemented yet."
+                    ),
+                )
+            elif self._is_gl_ground_archive(archive_name):
+                self._extract_gl_ground_archive(
+                    file_name,
+                    warnings=warnings,
+                    should_stop=should_stop,
+                )
+            elif self._is_gl_eliminate_raid_archive(archive_name):
+                self._extract_raw_zip_archive(
+                    file_name,
+                    warnings=warnings,
+                    should_stop=should_stop,
+                    info_message=(
+                        f"Extracted raw GL eliminateRaid payloads from {archive_name}; "
+                        "semantic parser is not implemented yet."
+                    ),
+                )
+            elif self._is_gl_enemy_boss_script_archive(archive_name):
+                self._extract_raw_zip_archive(
+                    file_name,
+                    warnings=warnings,
+                    should_stop=should_stop,
+                    info_message=(
+                        f"Extracted raw GL boss script payloads from {archive_name}; "
+                        "semantic parser is not implemented yet."
+                    ),
+                )
+            elif self._is_gl_raw_script_test_archive(archive_name):
+                self._extract_raw_zip_archive(
+                    file_name,
+                    warnings=warnings,
+                    should_stop=should_stop,
+                    info_message=(
+                        f"Extracted raw GL script/test payloads from {archive_name}; "
+                        "semantic parser is not implemented yet."
+                    ),
+                )
+            elif self._is_gl_numeric_stage_archive(archive_name):
+                self._extract_gl_numeric_stage_archive(
+                    file_name,
+                    warnings=warnings,
+                    should_stop=should_stop,
+                )
+            elif self._is_mgs_logic_ground_archive(archive_name):
+                self._extract_mgs_logic_ground_archive(
                     file_name,
                     warnings=warnings,
                     should_stop=should_stop,
@@ -609,6 +762,162 @@ class TableExtractor:
         self.logger.info(
             f"Extracted raw GroundStage payloads from {archive_name}; semantic parser is not implemented yet."
         )
+
+    def _extract_gl_ground_archive(
+        self,
+        file_name: str,
+        *,
+        warnings: list[str],
+        should_stop: Callable[[], bool] | None = None,
+    ) -> None:
+        archive_name = path.basename(file_name)
+        schema_name = self._resolve_gl_ground_schema_name(archive_name)
+        extract_folder = Path(self.extract_folder) / archive_name.removesuffix(".zip")
+
+        with ZipFile(path.join(self.table_file_folder, file_name), "r") as archive:
+            archive.setpassword(zip_password(archive_name))
+            for item_name in archive.namelist():
+                self._ensure_not_cancelled(should_stop)
+                try:
+                    item_data = archive.read(item_name)
+                except (RuntimeError, OSError, ValueError, zlib.error) as exc:
+                    self._warn_skipped_entry(
+                        archive_name,
+                        item_name,
+                        warnings,
+                        str(exc),
+                    )
+                    continue
+
+                try:
+                    processed_file = self._process_zip_file(
+                        archive_name,
+                        schema_name,
+                        item_data,
+                        detect_type=True,
+                    )
+                except TableProcessingError as exc:
+                    self._warn_skipped_entry(
+                        archive_name,
+                        item_name,
+                        warnings,
+                        str(exc),
+                    )
+                    continue
+
+                self._ensure_not_cancelled(should_stop)
+                self._write_processed_file(extract_folder, processed_file)
+
+    def _extract_gl_numeric_stage_archive(
+        self,
+        file_name: str,
+        *,
+        warnings: list[str],
+        should_stop: Callable[[], bool] | None = None,
+    ) -> None:
+        archive_name = path.basename(file_name)
+        extract_folder = Path(self.extract_folder) / archive_name.removesuffix(".zip")
+
+        with ZipFile(path.join(self.table_file_folder, file_name), "r") as archive:
+            archive.setpassword(zip_password(archive_name))
+            for item_name in archive.namelist():
+                self._ensure_not_cancelled(should_stop)
+                try:
+                    item_data = archive.read(item_name)
+                except (RuntimeError, OSError, ValueError, zlib.error) as exc:
+                    self._warn_skipped_entry(
+                        archive_name,
+                        item_name,
+                        warnings,
+                        str(exc),
+                    )
+                    continue
+
+                self._write_processed_file(
+                    extract_folder,
+                    ProcessedTableArtifact(
+                        data=item_data,
+                        file_name=path.basename(item_name),
+                    ),
+                )
+
+    def _extract_mgs_logic_ground_archive(
+        self,
+        file_name: str,
+        *,
+        warnings: list[str],
+        should_stop: Callable[[], bool] | None = None,
+    ) -> None:
+        archive_name = path.basename(file_name)
+        extract_folder = Path(self.extract_folder) / archive_name.removesuffix(".zip")
+
+        with ZipFile(path.join(self.table_file_folder, file_name), "r") as archive:
+            archive.setpassword(zip_password(archive_name))
+            for item_name in archive.namelist():
+                self._ensure_not_cancelled(should_stop)
+                try:
+                    item_data = archive.read(item_name)
+                except (RuntimeError, OSError, ValueError, zlib.error) as exc:
+                    self._warn_skipped_entry(
+                        archive_name,
+                        item_name,
+                        warnings,
+                        str(exc),
+                    )
+                    continue
+
+                try:
+                    processed_file = self._process_zip_file(
+                        archive_name,
+                        self.GROUND_GRID_SCHEMA_NAME,
+                        item_data,
+                        detect_type=True,
+                    )
+                except TableProcessingError:
+                    processed_file = ProcessedTableArtifact(
+                        data=item_data,
+                        file_name=path.basename(item_name),
+                    )
+
+                self._ensure_not_cancelled(should_stop)
+                self._write_processed_file(extract_folder, processed_file)
+
+    def _extract_raw_zip_archive(
+        self,
+        file_name: str,
+        *,
+        warnings: list[str],
+        should_stop: Callable[[], bool] | None = None,
+        info_message: str | None = None,
+    ) -> None:
+        archive_name = path.basename(file_name)
+        extract_folder = Path(self.extract_folder) / archive_name.removesuffix(".zip")
+
+        with ZipFile(path.join(self.table_file_folder, file_name), "r") as archive:
+            archive.setpassword(zip_password(archive_name))
+            for item_name in archive.namelist():
+                self._ensure_not_cancelled(should_stop)
+                try:
+                    item_data = archive.read(item_name)
+                except (RuntimeError, OSError, ValueError, zlib.error) as exc:
+                    self._warn_skipped_entry(
+                        archive_name,
+                        item_name,
+                        warnings,
+                        str(exc),
+                    )
+                    continue
+
+                self._write_processed_file(
+                    extract_folder,
+                    ProcessedTableArtifact(
+                        data=item_data,
+                        file_name=path.basename(item_name),
+                    ),
+                )
+
+        if info_message:
+            self.logger.info(info_message)
 
     def _extract_ground_stage_inner_archive(
         self,

--- a/src/ba_downloader/infrastructure/tools/dump_backend.py
+++ b/src/ba_downloader/infrastructure/tools/dump_backend.py
@@ -474,7 +474,7 @@ def build_default_dumper_backend_registry() -> DumperBackendRegistry:
         "cn", lambda http_client, logger: CnMetadataDumpBackend(http_client, logger)
     )
     registry.register(
-        "gl", lambda http_client, logger: LegacyIl2CppDumperBackend(http_client, logger)
+        "gl", lambda http_client, logger: Cpp2IlDumpCsBackend(http_client, logger)
     )
     registry.register(
         "jp", lambda http_client, logger: Cpp2IlDumpCsBackend(http_client, logger)

--- a/tests/test_dump_backend.py
+++ b/tests/test_dump_backend.py
@@ -129,7 +129,7 @@ def test_default_dumper_policy_maps_regions_to_expected_backends() -> None:
     )
     assert isinstance(
         registry.resolve("gl")(http_client, logger),
-        LegacyIl2CppDumperBackend,
+        Cpp2IlDumpCsBackend,
     )
     assert isinstance(
         registry.resolve("cn")(http_client, logger),

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -30,9 +30,30 @@ def test_settings_normalization_keeps_non_jp_default_directories() -> None:
         region="gl", platform="ios", platform_explicit=True
     ).normalized()
 
-    assert settings.temp_dir == "GLTemp"
-    assert settings.raw_dir == "GLRawData"
-    assert settings.extract_dir == "GLExtracted"
+    assert settings.temp_dir == "GL_Temp"
+    assert settings.raw_dir == "GL_RawData"
+    assert settings.extract_dir == "GL_Extracted"
+
+
+def test_settings_normalization_uses_underscored_cn_directories() -> None:
+    settings = AppSettings(region="cn").normalized()
+
+    assert settings.temp_dir == "CN_Temp"
+    assert settings.raw_dir == "CN_RawData"
+    assert settings.extract_dir == "CN_Extracted"
+
+
+def test_settings_normalization_preserves_custom_directories() -> None:
+    settings = AppSettings(
+        region="gl",
+        raw_dir="custom_raw",
+        extract_dir="custom_extract",
+        temp_dir="custom_temp",
+    ).normalized()
+
+    assert settings.raw_dir == "custom_raw"
+    assert settings.extract_dir == "custom_extract"
+    assert settings.temp_dir == "custom_temp"
 
 
 def test_runtime_context_copies_normalized_settings() -> None:

--- a/tests/test_table_extractor.py
+++ b/tests/test_table_extractor.py
@@ -13,6 +13,7 @@ from ba_downloader.domain.models.runtime import RuntimeContext
 from ba_downloader.infrastructure.extractors.table import (
     GeneratedDumpWrapperError,
     MalformedTablePayloadError,
+    ProcessedTableArtifact,
     TableDecryptError,
     TableExtractor,
     UnsupportedSchemaError,
@@ -57,7 +58,8 @@ def _create_flat_data_package(flat_data_dir: Path) -> None:
     flat_data_dir.mkdir(parents=True, exist_ok=True)
     (flat_data_dir / "__init__.py").write_text(
         "from .CharacterExcelTable import CharacterExcelTable\n"
-        "from .GroundGridFlat import GroundGridFlat\n",
+        "from .GroundGridFlat import GroundGridFlat\n"
+        "from .GroundNodeLayerFlat import GroundNodeLayerFlat\n",
         encoding="utf8",
     )
     (flat_data_dir / "CharacterExcelTable.py").write_text(
@@ -74,11 +76,20 @@ def _create_flat_data_package(flat_data_dir: Path) -> None:
         "        return cls()\n",
         encoding="utf8",
     )
+    (flat_data_dir / "GroundNodeLayerFlat.py").write_text(
+        "class GroundNodeLayerFlat:\n"
+        "    @classmethod\n"
+        "    def GetRootAs(cls, data):\n"
+        "        return cls()\n",
+        encoding="utf8",
+    )
     (flat_data_dir / "dump_wrapper.py").write_text(
         "def dump_table(table_instance):\n"
         '    return [{"kind": "excel"}]\n\n'
         'def dump_GroundGridFlat(excel_instance, password: bytes = b""):\n'
-        '    return {"kind": "ground_grid"}\n',
+        '    return {"kind": "ground_grid"}\n\n'
+        'def dump_GroundNodeLayerFlat(excel_instance, password: bytes = b""):\n'
+        '    return {"kind": "ground_node_layer"}\n',
         encoding="utf8",
     )
 
@@ -342,6 +353,484 @@ def test_extract_zip_file_writes_ground_stage_raw_payloads(tmp_path: Path) -> No
     assert logger.info_messages == [
         "Extracted raw GroundStage payloads from TablePatchPack_GroundStage_1.zip; semantic parser is not implemented yet."
     ]
+
+
+def test_extract_zip_file_writes_gl_battle_stage_artifact(tmp_path: Path) -> None:
+    context = _build_context(tmp_path)
+    flat_data_dir = Path(context.extract_dir) / "FlatData"
+    _create_flat_data_package(flat_data_dir)
+    table_dir = Path(context.raw_dir) / "Table"
+    table_dir.mkdir(parents=True, exist_ok=True)
+
+    with ZipFile(table_dir / "sb_02_desertcity_p01_e.zip", "w") as archive:
+        archive.writestr("sb_02_desertcity_p01_e.bytes", b"\xff\x00grid")
+
+    logger = RecordingLogger()
+    extractor = TableExtractor(
+        str(table_dir),
+        str(Path(context.extract_dir)),
+        str(flat_data_dir),
+        logger=logger,
+    )
+
+    extractor.extract_zip_file("sb_02_desertcity_p01_e.zip")
+
+    output_path = (
+        Path(context.extract_dir)
+        / "sb_02_desertcity_p01_e"
+        / "GroundGridFlat.json"
+    )
+    assert output_path.is_file()
+    assert json.loads(output_path.read_text(encoding="utf8")) == {"kind": "ground_grid"}
+    assert logger.warn_messages == []
+    assert logger.error_messages == []
+
+
+def test_extract_zip_file_writes_gl_battle_stage_nodelayer_artifact(
+    tmp_path: Path,
+) -> None:
+    context = _build_context(tmp_path)
+    flat_data_dir = Path(context.extract_dir) / "FlatData"
+    _create_flat_data_package(flat_data_dir)
+    table_dir = Path(context.raw_dir) / "Table"
+    table_dir.mkdir(parents=True, exist_ok=True)
+
+    with ZipFile(table_dir / "sb_02_desertcity_p01_e_nodelayer.zip", "w") as archive:
+        archive.writestr("sb_02_desertcity_p01_e_nodelayer.bytes", b"\xff\x00node")
+
+    logger = RecordingLogger()
+    extractor = TableExtractor(
+        str(table_dir),
+        str(Path(context.extract_dir)),
+        str(flat_data_dir),
+        logger=logger,
+    )
+
+    extractor.extract_zip_file("sb_02_desertcity_p01_e_nodelayer.zip")
+
+    output_path = (
+        Path(context.extract_dir)
+        / "sb_02_desertcity_p01_e_nodelayer"
+        / "GroundNodeLayerFlat.json"
+    )
+    assert output_path.is_file()
+    assert json.loads(output_path.read_text(encoding="utf8")) == {
+        "kind": "ground_node_layer"
+    }
+    assert logger.warn_messages == []
+    assert logger.error_messages == []
+
+
+@pytest.mark.parametrize(
+    ("archive_name", "entry_name", "payload", "expected_file_name", "expected_json"),
+    [
+        (
+            "rb_03_hod_p01.zip",
+            "rb_03_hod_p01.bytes",
+            b"\xff\x00grid",
+            "GroundGridFlat.json",
+            {"kind": "ground_grid"},
+        ),
+        (
+            "rb_03_hieronymus_p01_d_scenario.zip",
+            "rb_03_hieronymus_p01_d_scenario.bytes",
+            b"\xff\x00grid",
+            "GroundGridFlat.json",
+            {"kind": "ground_grid"},
+        ),
+        (
+            "rd_02_EN0011_p01_d_01_nodelayer.zip",
+            "rd_02_en0011_p01_d_01_nodelayer.bytes",
+            b"\xff\x00node",
+            "GroundNodeLayerFlat.json",
+            {"kind": "ground_node_layer"},
+        ),
+        (
+            "db_02_beachstage_01_nodelayer.zip",
+            "db_02_beachstage_01_nodelayer.bytes",
+            b"\xff\x00node",
+            "GroundNodeLayerFlat.json",
+            {"kind": "ground_node_layer"},
+        ),
+    ],
+)
+def test_extract_zip_file_writes_additional_gl_ground_artifacts(
+    tmp_path: Path,
+    archive_name: str,
+    entry_name: str,
+    payload: bytes,
+    expected_file_name: str,
+    expected_json: dict[str, str],
+) -> None:
+    context = _build_context(tmp_path)
+    flat_data_dir = Path(context.extract_dir) / "FlatData"
+    _create_flat_data_package(flat_data_dir)
+    table_dir = Path(context.raw_dir) / "Table"
+    table_dir.mkdir(parents=True, exist_ok=True)
+
+    with ZipFile(table_dir / archive_name, "w") as archive:
+        archive.writestr(entry_name, payload)
+
+    logger = RecordingLogger()
+    extractor = TableExtractor(
+        str(table_dir),
+        str(Path(context.extract_dir)),
+        str(flat_data_dir),
+        logger=logger,
+    )
+
+    extractor.extract_zip_file(archive_name)
+
+    output_path = Path(context.extract_dir) / archive_name.removesuffix(".zip") / expected_file_name
+    assert output_path.is_file()
+    assert json.loads(output_path.read_text(encoding="utf8")) == expected_json
+    assert logger.warn_messages == []
+    assert logger.error_messages == []
+
+
+def test_extract_zip_file_writes_c_sb_hyakkiyakomatsuri_raw_artifact(
+    tmp_path: Path,
+) -> None:
+    context = _build_context(tmp_path)
+    flat_data_dir = Path(context.extract_dir) / "FlatData"
+    _create_flat_data_package(flat_data_dir)
+    table_dir = Path(context.raw_dir) / "Table"
+    table_dir.mkdir(parents=True, exist_ok=True)
+
+    archive_name = "C_sb_01_hyakkiyakomatsuri_p02_Little.zip"
+    entry_name = "c_sb_01_hyakkiyakomatsuri_p02_little.bytes"
+    payload = b"\x06\xfc\xff\xffbattle"
+    with ZipFile(table_dir / archive_name, "w") as archive:
+        archive.writestr(entry_name, payload)
+
+    logger = RecordingLogger()
+    extractor = TableExtractor(
+        str(table_dir),
+        str(Path(context.extract_dir)),
+        str(flat_data_dir),
+        logger=logger,
+    )
+
+    extractor.extract_zip_file(archive_name)
+
+    output_path = Path(context.extract_dir) / archive_name.removesuffix(".zip") / entry_name
+    assert output_path.is_file()
+    assert output_path.read_bytes() == payload
+    assert logger.warn_messages == []
+    assert logger.error_messages == []
+    assert logger.info_messages == [
+        "Extracted raw GL C_sb script payloads from "
+        "C_sb_01_hyakkiyakomatsuri_p02_Little.zip; "
+        "semantic parser is not implemented yet."
+    ]
+
+
+@pytest.mark.parametrize(
+    "archive_name,entry_name",
+    [
+        (
+            "C_sb_01_destroyhyakkiyakomatsuri_p01_Many.zip",
+            "c_sb_01_destroyhyakkiyakomatsuri_p01_many.bytes",
+        ),
+        (
+            "C_sb_01_wildhuntstreet_p02_Many.zip",
+            "c_sb_01_wildhuntstreet_p02_many.bytes",
+        ),
+        (
+            "C_sb_03_expresstrain_p01_Little.zip",
+            "c_sb_03_expresstrain_p01_little.bytes",
+        ),
+        (
+            "C_sb_01_hyakkiyakomoviestreet_p01_Many.zip",
+            "c_sb_01_hyakkiyakomoviestreet_p01_many.bytes",
+        ),
+    ],
+)
+def test_extract_zip_file_writes_c_sb_script_raw_payloads(
+    tmp_path: Path,
+    archive_name: str,
+    entry_name: str,
+) -> None:
+    context = _build_context(tmp_path)
+    flat_data_dir = Path(context.extract_dir) / "FlatData"
+    _create_flat_data_package(flat_data_dir)
+    table_dir = Path(context.raw_dir) / "Table"
+    table_dir.mkdir(parents=True, exist_ok=True)
+
+    payload = b"\x06\xfc\xff\xffbattle"
+    with ZipFile(table_dir / archive_name, "w") as archive:
+        archive.writestr(entry_name, payload)
+
+    logger = RecordingLogger()
+    extractor = TableExtractor(
+        str(table_dir),
+        str(Path(context.extract_dir)),
+        str(flat_data_dir),
+        logger=logger,
+    )
+
+    extractor.extract_zip_file(archive_name)
+
+    output_path = Path(context.extract_dir) / archive_name.removesuffix(".zip") / entry_name
+    assert output_path.is_file()
+    assert output_path.read_bytes() == payload
+    assert logger.warn_messages == []
+    assert logger.error_messages == []
+    assert logger.info_messages == [
+        "Extracted raw GL C_sb script payloads from "
+        f"{archive_name}; "
+        "semantic parser is not implemented yet."
+    ]
+
+
+@pytest.mark.parametrize(
+    ("archive_name", "entry_name"),
+    [
+        (
+            "1041104_03_s3_boss_02_desertcity_p01_d.zip",
+            "1041104_03_s3_boss_02_desertcity_p01_d.bytes",
+        ),
+        (
+            "1052101_01_s2_02_deserttrack_p01_n.zip",
+            "1052101_01_s2_02_deserttrack_p01_n.bytes",
+        ),
+    ],
+)
+def test_extract_zip_file_writes_gl_numeric_stage_raw_payloads(
+    tmp_path: Path,
+    archive_name: str,
+    entry_name: str,
+) -> None:
+    context = _build_context(tmp_path)
+    flat_data_dir = Path(context.extract_dir) / "FlatData"
+    _create_flat_data_package(flat_data_dir)
+    table_dir = Path(context.raw_dir) / "Table"
+    table_dir.mkdir(parents=True, exist_ok=True)
+
+    payload = b"\x06\xfc\xff\xffbattle"
+    with ZipFile(table_dir / archive_name, "w") as archive:
+        archive.writestr(entry_name, payload)
+
+    logger = RecordingLogger()
+    extractor = TableExtractor(
+        str(table_dir),
+        str(Path(context.extract_dir)),
+        str(flat_data_dir),
+        logger=logger,
+    )
+
+    extractor.extract_zip_file(archive_name)
+
+    output_path = Path(context.extract_dir) / archive_name.removesuffix(".zip") / entry_name
+    assert output_path.is_file()
+    assert output_path.read_bytes() == payload
+    assert logger.warn_messages == []
+    assert logger.error_messages == []
+
+
+def test_extract_zip_file_writes_gl_eliminate_raid_raw_payloads(
+    tmp_path: Path,
+) -> None:
+    context = _build_context(tmp_path)
+    flat_data_dir = Path(context.extract_dir) / "FlatData"
+    _create_flat_data_package(flat_data_dir)
+    table_dir = Path(context.raw_dir) / "Table"
+    table_dir.mkdir(parents=True, exist_ok=True)
+
+    archive_name = "6062106_eliminateRaid_perorozilla_outdoor_light_insane_start2phase.zip"
+    entry_name = "6062106_eliminateraid_perorozilla_outdoor_light_insane_start2phase.bytes"
+    payload = b"\x06\xfc\xff\xffbattle"
+    with ZipFile(table_dir / archive_name, "w") as archive:
+        archive.writestr(entry_name, payload)
+
+    logger = RecordingLogger()
+    extractor = TableExtractor(
+        str(table_dir),
+        str(Path(context.extract_dir)),
+        str(flat_data_dir),
+        logger=logger,
+    )
+
+    extractor.extract_zip_file(archive_name)
+
+    output_path = Path(context.extract_dir) / archive_name.removesuffix(".zip") / entry_name
+    assert output_path.is_file()
+    assert output_path.read_bytes() == payload
+    assert logger.warn_messages == []
+    assert logger.error_messages == []
+    assert logger.info_messages == [
+        "Extracted raw GL eliminateRaid payloads from "
+        "6062106_eliminateRaid_perorozilla_outdoor_light_insane_start2phase.zip; "
+        "semantic parser is not implemented yet."
+    ]
+
+
+@pytest.mark.parametrize(
+    ("archive_name", "entry_name"),
+    [
+        ("EN0006_Eliminate_LightArmor_Hard.zip", "en0006_eliminate_lightarmor_hard.bytes"),
+        ("EN0006_VeryHard.zip", "en0006_veryhard.bytes"),
+        ("EN0013_Torment_3Phase.zip", "en0013_torment_3phase.bytes"),
+    ],
+)
+def test_extract_zip_file_writes_gl_enemy_boss_script_raw_payloads(
+    tmp_path: Path,
+    archive_name: str,
+    entry_name: str,
+) -> None:
+    context = _build_context(tmp_path)
+    flat_data_dir = Path(context.extract_dir) / "FlatData"
+    _create_flat_data_package(flat_data_dir)
+    table_dir = Path(context.raw_dir) / "Table"
+    table_dir.mkdir(parents=True, exist_ok=True)
+
+    payload = b"\x06\xfc\xff\xffbattle"
+    with ZipFile(table_dir / archive_name, "w") as archive:
+        archive.writestr(entry_name, payload)
+
+    logger = RecordingLogger()
+    extractor = TableExtractor(
+        str(table_dir),
+        str(Path(context.extract_dir)),
+        str(flat_data_dir),
+        logger=logger,
+    )
+
+    extractor.extract_zip_file(archive_name)
+
+    output_path = Path(context.extract_dir) / archive_name.removesuffix(".zip") / entry_name
+    assert output_path.is_file()
+    assert output_path.read_bytes() == payload
+    assert logger.warn_messages == []
+    assert logger.error_messages == []
+    assert logger.info_messages == [
+        f"Extracted raw GL boss script payloads from {archive_name}; semantic parser is not implemented yet."
+    ]
+
+
+@pytest.mark.parametrize(
+    ("archive_name", "entry_name"),
+    [
+        ("DamageTest_Street_LightArmor.zip", "damagetest_street_lightarmor.bytes"),
+        ("character_resource_video_03.zip", "character_resource_video_03.bytes"),
+        ("chesedscenariotest.zip", "chesedscenariotest.bytes"),
+        ("CH0265Test.zip", "ch0265test.bytes"),
+        ("BaseMentTest.zip", "basementtest.bytes"),
+        ("combattest_hod01.zip", "combattest_hod01.bytes"),
+        ("EffectCountLimitTest_Limit.zip", "effectcountlimittest_limit.bytes"),
+        ("EmojiTest.zip", "emojitest.bytes"),
+        ("AriusStreet_p01_n_Many_ObsTest.zip", "ariusstreet_p01_n_many_obstest.bytes"),
+        ("colourtimelinetest.zip", "colourtimelinetest.bytes"),
+        ("CameraRotateTest.zip", "camerarotatetest.bytes"),
+        ("ChangeLookTargetTest.zip", "changelooktargettest.bytes"),
+        ("GroundPassiveTest01.zip", "groundpassivetest01.bytes"),
+        ("HoldTest.zip", "holdtest.bytes"),
+        ("HoverCraftTest.zip", "hovercrafttest.bytes"),
+        ("hyakkiyako.zip", "hyakkiyako.bytes"),
+        ("newyearpathvisualtest_p01.zip", "newyearpathvisualtest_p01.bytes"),
+        ("NP186Test.zip", "np186test.bytes"),
+        ("NPCTEST.zip", "npctest.bytes"),
+        ("OverrideTest_Normal.zip", "overridetest_normal.bytes"),
+        ("playground_obstacleset_little.zip", "playground_obstacleset_little.bytes"),
+        ("RaidTest.zip", "raidtest.bytes"),
+        ("9970_WorldEmojiTest.zip", "9970_worldemojitest.bytes"),
+        ("CH0265Test2.zip", "ch0265test2.bytes"),
+    ],
+)
+def test_extract_zip_file_writes_gl_script_test_raw_payloads(
+    tmp_path: Path,
+    archive_name: str,
+    entry_name: str,
+) -> None:
+    context = _build_context(tmp_path)
+    flat_data_dir = Path(context.extract_dir) / "FlatData"
+    _create_flat_data_package(flat_data_dir)
+    table_dir = Path(context.raw_dir) / "Table"
+    table_dir.mkdir(parents=True, exist_ok=True)
+
+    payload = b"\x06\xfc\xff\xffbattle"
+    with ZipFile(table_dir / archive_name, "w") as archive:
+        archive.writestr(entry_name, payload)
+
+    logger = RecordingLogger()
+    extractor = TableExtractor(
+        str(table_dir),
+        str(Path(context.extract_dir)),
+        str(flat_data_dir),
+        logger=logger,
+    )
+
+    extractor.extract_zip_file(archive_name)
+
+    output_path = Path(context.extract_dir) / archive_name.removesuffix(".zip") / entry_name
+    assert output_path.is_file()
+    assert output_path.read_bytes() == payload
+    assert logger.warn_messages == []
+    assert logger.error_messages == []
+    assert logger.info_messages == [
+        f"Extracted raw GL script/test payloads from {archive_name}; semantic parser is not implemented yet."
+    ]
+
+
+def test_extract_zip_file_writes_mgs_logic_ground_mixed_artifacts(
+    tmp_path: Path,
+) -> None:
+    context = _build_context(tmp_path)
+    flat_data_dir = Path(context.extract_dir) / "FlatData"
+    _create_flat_data_package(flat_data_dir)
+    table_dir = Path(context.raw_dir) / "Table"
+    table_dir.mkdir(parents=True, exist_ok=True)
+
+    with ZipFile(table_dir / "MGSLogicGroundData.zip", "w") as archive:
+        archive.writestr("logicground_free.bytes", b"\xff\x00grid")
+        archive.writestr("logicground_hard.bytes", b"\xff\x00bad-grid")
+
+    logger = RecordingLogger()
+    extractor = TableExtractor(
+        str(table_dir),
+        str(Path(context.extract_dir)),
+        str(flat_data_dir),
+        logger=logger,
+    )
+
+    original_process_zip_file = extractor._process_zip_file
+
+    def fake_process_zip_file(
+        archive_name: str,
+        file_name: str,
+        file_data: bytes,
+        *,
+        detect_type: bool = False,
+    ) -> ProcessedTableArtifact:
+        if file_data == b"\xff\x00bad-grid":
+            raise UnsupportedSchemaError("grid parser failed")
+        return original_process_zip_file(
+            archive_name,
+            file_name,
+            file_data,
+            detect_type=detect_type,
+        )
+
+    extractor._process_zip_file = fake_process_zip_file  # type: ignore[method-assign]
+
+    extractor.extract_zip_file("MGSLogicGroundData.zip")
+
+    grid_output = (
+        Path(context.extract_dir)
+        / "MGSLogicGroundData"
+        / "GroundGridFlat.json"
+    )
+    raw_output = (
+        Path(context.extract_dir)
+        / "MGSLogicGroundData"
+        / "logicground_hard.bytes"
+    )
+    assert grid_output.is_file()
+    assert json.loads(grid_output.read_text(encoding="utf8")) == {"kind": "ground_grid"}
+    assert raw_output.is_file()
+    assert raw_output.read_bytes() == b"\xff\x00bad-grid"
+    assert logger.warn_messages == []
+    assert logger.error_messages == []
 
 
 def test_extract_zip_file_skips_ground_stage_entries_with_zlib_errors(


### PR DESCRIPTION
## Summary

- Preserve unsupported GL table/script payloads as raw extracted files instead of treating them as hard extraction failures.
- Add GL eliminateRaid analysis notes and update development/user documentation around the current raw-export behavior.
- Add JP platform-specific default directory handling, CLI help coverage, and CI validation across Python 3.10 through 3.13.

## Impact

- GL `extract`/`sync` table flows can now keep currently unsupported payloads available for later analysis.
- JP default output directories vary by platform when the default logical directory names are unchanged.
- CI now validates the declared Python `>=3.10` support range more directly.

## Compatibility

- No CLI command names were changed.
- JP default output paths are more platform-specific for default directory values; explicit custom directories remain preserved.

## Validation

- `powershell -ExecutionPolicy Bypass -File scripts/run-preflight.ps1`
- `pytest -q`: 191 passed
- `ruff check .`: passed
- `mypy`: passed
- `pylint`: advisory warnings only