### PR TITLE
chore(release): prepare v2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,34 @@
 
 - No unreleased changes recorded.
 
+
+## v2.1.0 - 2026-05-26
+
+### Features
+- stabilize schema and extraction pipeline
+- preserve GL raw payload exports
+
+### Fixes
+- resolve default remote fallback
+- route worker logs through parent
+
+### Refactors
+- reduce redundant schema infrastructure
+- reorganize project boundaries
+- reduce infrastructure complexity
+
+### Chores
+- sync readme docs and ci submodules
+- require net10 tooling
+- upgrade project dependencies
+- switch to main-only release workflow
+
+### Other Changes
+- Merge pull request #9 from ZM-Kimu/refactor/reduce-complexity
+- Merge pull request #8 from ZM-Kimu/feat/gl-runtime-and-relation-flow
+- Merge pull request #7 from ZM-Kimu/feat/gl-runtime-and-relation-flow
+
+
 ## v2.0.0 - 2026-04-10
 
 ### Release

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ba-downloader"
-version = "2.0.0"
+version = "2.1.0"
 description = "Blue Archive multi-region asset downloader and extractor"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/scripts/release.ps1
+++ b/scripts/release.ps1
@@ -103,7 +103,7 @@ function Get-PreferredRemote {
         }
     }
 
-    if (Test-GitRef -RefName "origin/HEAD" -or Test-GitRef -RefName "origin/main") {
+    if ((Test-GitRef -RefName "origin/HEAD") -or (Test-GitRef -RefName "origin/main")) {
         return "origin"
     }
 


### PR DESCRIPTION
## Summary
- Bump package metadata to `2.1.0`.
- Finalize `CHANGELOG.md` with the `v2.1.0 - 2026-05-26` release notes.
- Fix the release helper default remote fallback so release preparation works without an `origin` remote.

## Release behavior
After this PR is merged into `main`, `.github/workflows/tag-release.yml` will create tag `v2.1.0` and publish the GitHub Release from `CHANGELOG.md`.

## Validation
- `pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/release.ps1 -Version 2.1.0 -BaseRef v2.0.0 -HeadRef HEAD -NonInteractive`
- `python scripts/update_changelog.py release-notes --version 2.1.0 --path CHANGELOG.md --output .tmp-release-notes.md`
- `uv build`
- `git diff --check`
