### PR TITLE
[codex] enable CN advanced search

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@
 
 ## 主要功能
 - **资源解开**：在日本服务器中包含几乎完整的支持。
-- **CN 阶段成果**：当前 `download --region cn`、`sync --region cn`、`character-index build --region cn` 已可用；`--advanced-search` 仍未开放。
-- **JP 阶段成果**：当前 `download --region jp`、`sync --region jp`、`character-index build --region jp` 已可用；`--advanced-search` 仍未开放。
+- **CN 阶段成果**：当前 `download --region cn`、`sync --region cn`、`character-index build --region cn` 与 `--advanced-search` 已可用。
+- **JP 阶段成果**：当前 `download --region jp`、`sync --region jp`、`character-index build --region jp` 与 `--advanced-search` 已可用。
 
 
 ## 资源类型
@@ -134,14 +134,19 @@ python -m ba_downloader sync --region jp
 ---
 #### 并且，在不同的服务器中亦支持不同的名称检索方式，具体内容请参照`<Region>CharacterIndex.json`。
 - 示例：
-  > sync
-  >```sh
-  >ba-downloader sync --region gl -as 貝雅特里榭 ยูเมะ ibuki
-  >```
-
   > japan
   >```sh
   >ba-downloader sync --region jp -as yume 百合園セイア 호시노 cv=小倉唯 height=153 birthday=2/19 illustrator=YutokaMizu school=Arius club=GameDev
+  >```
+
+  > global
+  >```sh
+  >ba-downloader sync --region gl -as 貝雅特里榭 ยูเมะ mika
+  >```
+
+  > china
+  >```sh
+  >ba-downloader sync --region cn -as 伊吹 黑服
   >```
 
 - 普通检索：

--- a/docs/README.en.md
+++ b/docs/README.en.md
@@ -12,8 +12,8 @@ This project downloads and extracts Blue Archive assets from different servers. 
 ## Main Features
 
 - **Asset extraction**: JP currently has nearly complete support.
-- **CN milestone status**: `download --region cn`, `sync --region cn`, and `character-index build --region cn` are currently available; `--advanced-search` is still unavailable.
-- **JP milestone status**: `download --region jp`, `sync --region jp`, and `character-index build --region jp` are currently available; `--advanced-search` is still unavailable.
+- **CN milestone status**: `download --region cn`, `sync --region cn`, `character-index build --region cn`, and `--advanced-search` are currently available.
+- **JP milestone status**: `download --region jp`, `sync --region jp`, `character-index build --region jp`, and `--advanced-search` are currently available.
 
 
 ## Resource Types

--- a/src/ba_downloader/infrastructure/regions/cn/provider.py
+++ b/src/ba_downloader/infrastructure/regions/cn/provider.py
@@ -25,7 +25,6 @@ from ba_downloader.infrastructure.packages import (
 )
 from ba_downloader.infrastructure.packages.zip_range_reader import ZipEntryNotFoundError
 from ba_downloader.infrastructure.regions.common import (
-    SYNC_AND_RELATION_CAPABILITIES,
     build_region_catalog_result,
     coerce_int,
     join_catalog_url,
@@ -34,7 +33,11 @@ from ba_downloader.infrastructure.regions.common import (
 
 
 class CNRegionProvider:
-    CAPABILITIES = SYNC_AND_RELATION_CAPABILITIES
+    CAPABILITIES = RegionCapabilities(
+        supports_sync=True,
+        supports_advanced_search=True,
+        supports_character_index_build=True,
+    )
     APK_MEDIA_SOURCE = "apk_entry"
     APK_MEDIA_PREFIXES: ClassVar[tuple[str, ...]] = ("assets/video/",)
 

--- a/src/ba_downloader/infrastructure/regions/common.py
+++ b/src/ba_downloader/infrastructure/regions/common.py
@@ -3,16 +3,10 @@ from __future__ import annotations
 from collections.abc import Callable
 from urllib.parse import urljoin
 
-from ba_downloader.domain.models.asset import AssetCollection, RegionCapabilities
+from ba_downloader.domain.models.asset import AssetCollection
 from ba_downloader.domain.models.region_catalog import RegionCatalogResult
 from ba_downloader.domain.models.runtime import RuntimeContext
 from ba_downloader.domain.ports.logging import LoggerPort
-
-SYNC_AND_RELATION_CAPABILITIES = RegionCapabilities(
-    supports_sync=True,
-    supports_advanced_search=False,
-    supports_character_index_build=True,
-)
 
 
 def coerce_int(value: object) -> int:

--- a/tests/test_provider_results.py
+++ b/tests/test_provider_results.py
@@ -438,7 +438,7 @@ def test_cn_provider_builds_assets_without_downloading_apk(
         AssetType.media,
     ]
     assert provider.get_capabilities().supports_sync is True
-    assert provider.get_capabilities().supports_advanced_search is False
+    assert provider.get_capabilities().supports_advanced_search is True
     assert provider.get_capabilities().supports_character_index_build is True
     assert [item.checksum.algorithm for item in result.resources] == [
         "md5",

--- a/tests/test_sync_service.py
+++ b/tests/test_sync_service.py
@@ -278,6 +278,38 @@ def test_jp_sync_advanced_search_uses_relation_keywords(tmp_path: Path) -> None:
     assert extract_service.resource_calls == [["Bundle/Shiroko.bundle"]]
 
 
+def test_cn_sync_advanced_search_uses_character_index_keywords(
+    tmp_path: Path,
+) -> None:
+    context = _build_context(tmp_path).with_updates(
+        region="cn",
+        advanced_search=("伊吹",),
+    )
+    downloader = RecordingDownloader()
+    extract_service = RecordingExtractAssetsUseCase()
+    schema_preparation = RecordingSchemaPreparation()
+    character_index_builder = DummyCharacterIndexBuilder()
+    provider = StaticProvider(_build_search_catalog(context))
+    logger = RecordingLogger()
+    service = SyncAssetsUseCase(
+        provider,
+        downloader,
+        extract_service,  # type: ignore[arg-type]
+        schema_preparation,
+        lambda _context: character_index_builder,
+        logger,
+        workflow_profile=_build_profile(context, provider, logger),
+    )
+
+    service.run(context)
+
+    assert schema_preparation.calls == ["prepare"]
+    assert character_index_builder.search_calls == [["伊吹"]]
+    assert downloader.calls == [["Bundle/Shiroko.bundle"]]
+    assert extract_service.calls == ["run_post_download"]
+    assert extract_service.resource_calls == [["Bundle/Shiroko.bundle"]]
+
+
 def test_jp_sync_advanced_search_builds_missing_relation(tmp_path: Path) -> None:
     context = _build_context(tmp_path).with_updates(
         region="jp",


### PR DESCRIPTION
## Summary

- enable CN advanced search capability
- keep CN character-index build path and add sync advanced-search coverage
- update README status and CN advanced-search example

## Validation

- `uv run pytest tests/test_provider_results.py tests/test_sync_service.py tests/test_extract_service.py -q`
- `uv run pytest` (392 passed)
- `uv run black --check src tests`
- `uv run ruff check .`
- `uv run mypy`
- `git diff --check`