### PR TITLE
fix(cn): update metadata recovery and character index sources

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,10 @@
 - All code must be written in English: naming, comments, errors, CLI help, and example commands.
 - Documentation may be written in Chinese.
 
+## Project Statement
+- Any network request involved in this project must be performed with authorized approval. Network request code in this project is for learning purposes only.
+- This project only parses game assets and does not involve illegal behavior such as in-game anti-cheat bypassing.
+
 ## Workflow
 - Read relevant files/documents first, then provide a brief plan in Chinese with 3–6 bullet points.
 - During implementation, keep the code style in English and prioritize reusing existing models, ports, boundaries, and project style.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@
 - No unreleased changes recorded.
 
 
+## v2.2.1 - 2026-07-18
+
+### Fixes
+- update metadata recovery and character index sources
+
+
 ## v2.2.0 - 2026-07-09
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ ba-downloader download --region jp --platform windows
   - 处理 GL Table 解开
   
 ## 关于项目
-Blue Archive Asset Downloader v2.2.0.
+Blue Archive Asset Downloader v2.2.1.
 
 ✨ 技术支持：Codex ✨
 

--- a/README.md
+++ b/README.md
@@ -168,12 +168,11 @@ ba-downloader download --region jp --platform windows
 ## 使用须知
 - `--platform` 仅对 JP 生效，用于指定 JP 平台的资源。
 - `--version` 仅对 GL 生效；CN/JP 会自动解析当前可用版本。
-- CN dump 会自动使用 CN metadata recovery backend，并保持输出 `<Extracted>/Dumps/dump.cs` 与 `memorypack_formatters.json`。
 - JP的APK文件来自于APKPure，在PlayStore已经更新后，APKPure可能需要一些时间来同步版本。
 - 当各服务器处于维护时间时，可能会无法获取资源目录。
 - 在某些地区可能需要使用代理服务器以下载特定服务器的游戏资源。
 - Bundle文件的提取基于UnityPy，如希望更加详细的内容请使用[AssetRipper](https://github.com/AssetRipper/AssetRipper)或[AssetStudio](https://github.com/Perfare/AssetStudio)
-- 由于解开方法经常变更，各类接口会频繁变动，不建议直接调用内部方法。
+- 由于各类接口频繁变动，不建议直接调用内部方法。
 
 ## TODO
 - `v2.3.0`

--- a/docs/README.en.md
+++ b/docs/README.en.md
@@ -187,7 +187,7 @@ ba-downloader download --region jp --platform windows
 
 ## About
 
-Blue Archive Asset Downloader v2.2.0.
+Blue Archive Asset Downloader v2.2.1.
 
 Technical support: Codex
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ba-downloader"
-version = "2.2.0"
+version = "2.2.1"
 description = "Blue Archive multi-region asset downloader and extractor"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/ba_downloader/infrastructure/extraction/character/index_sources.py
+++ b/src/ba_downloader/infrastructure/extraction/character/index_sources.py
@@ -65,6 +65,9 @@ class DatabaseIndexSourceSpec:
     scenario_table: str
     character_table: str
     profile_table: str
+    costume_table: str | None = None
+    shop_recruit_table: str | None = None
+    localize_gacha_table: str | None = None
 
     @property
     def required_sources(self) -> tuple[str, str, str]:
@@ -122,6 +125,11 @@ class CharacterIndexSourceLoader:
         scenario_db = self.extract_db_table(spec.scenario_table)
         char_excel = self.extract_db_bytes_payloads(spec.character_table)
         char_profile = self.extract_db_bytes_payloads(spec.profile_table)
+        costume_excel = self.extract_optional_db_bytes_payloads(spec.costume_table)
+        shop_recruit = self.extract_optional_db_bytes_payloads(spec.shop_recruit_table)
+        localize_gacha = self.extract_optional_db_bytes_payloads(
+            spec.localize_gacha_table
+        )
 
         self.validate_index_sources(
             source_payloads={
@@ -136,9 +144,9 @@ class CharacterIndexSourceLoader:
             scenario_db=scenario_db,
             char_profile=char_profile,
             char_excel=char_excel,
-            costume_excel=[],
-            shop_recruit=[],
-            localize_gacha=[],
+            costume_excel=costume_excel,
+            shop_recruit=shop_recruit,
+            localize_gacha=localize_gacha,
         )
 
     def extract_scenario_db(self) -> list[dict[str, Any]]:
@@ -160,6 +168,17 @@ class CharacterIndexSourceLoader:
             if isinstance(payload, dict) and payload:
                 payloads.append(payload)
         return payloads
+
+    def extract_optional_db_bytes_payloads(
+        self,
+        table_name: str | None,
+    ) -> list[dict[str, Any]]:
+        if not table_name:
+            return []
+        try:
+            return self.extract_db_bytes_payloads(table_name)
+        except LookupError:
+            return []
 
     def extract_excel_bytes_files(self) -> dict[str, Path]:
         excel_folder = Path(self._table_source.table_file_folder)

--- a/src/ba_downloader/infrastructure/regions/cn/character_index.py
+++ b/src/ba_downloader/infrastructure/regions/cn/character_index.py
@@ -9,11 +9,30 @@ from ba_downloader.infrastructure.extraction.character.index_composer import (
     append_names,
 )
 from ba_downloader.infrastructure.extraction.character.index_sources import (
+    CharacterIndexSourceLoader,
     CharacterIndexSources,
+    DatabaseIndexSourceSpec,
+)
+
+CN_DATABASE_INDEX_SOURCE_SPEC = DatabaseIndexSourceSpec(
+    scenario_table="ScenarioCharacterNameDBSchema",
+    character_table="CharacterDBSchema",
+    profile_table="LocalizeCharProfileDBSchema",
+    costume_table="CostumeDBSchema",
+    shop_recruit_table="ShopRecruitDBSchema",
+    localize_gacha_table="LocalizeGachaShopDBSchema",
 )
 
 
-class CnArchiveCharacterIndexEnricher:
+class CnDbCharacterIndexSourceProfile:
+    def load(
+        self,
+        loader: CharacterIndexSourceLoader,
+    ) -> CharacterIndexSources:
+        return loader.load_database_index_sources(CN_DATABASE_INDEX_SOURCE_SPEC)
+
+
+class CnCharacterIndexEnricher:
     def enrich(
         self,
         composer: CharacterIndexComposer,

--- a/src/ba_downloader/infrastructure/regions/cn/dump_backend.py
+++ b/src/ba_downloader/infrastructure/regions/cn/dump_backend.py
@@ -57,6 +57,7 @@ class CnMetadataRecoveryDumpBackend(Cpp2IlDumpCsBackend):
 
         recovery_dir = base_dir / self.RECOVERY_FOLDER
         try:
+            self.logger.info("Starting CN metadata recovery.")
             recovery_result = self.recovery_pipeline.run(
                 protected_metadata=metadata_path.read_bytes(),
                 binary_path=binary_path,

--- a/src/ba_downloader/infrastructure/regions/cn/profile.py
+++ b/src/ba_downloader/infrastructure/regions/cn/profile.py
@@ -29,11 +29,9 @@ from ba_downloader.infrastructure.extraction.table.payload_router import (
 from ba_downloader.infrastructure.extraction.table.profiles import (
     TableExtractionProfile,
 )
-from ba_downloader.infrastructure.regions.archive_character_index import (
-    ArchiveCharacterIndexSourceProfile,
-)
 from ba_downloader.infrastructure.regions.cn.character_index import (
-    CnArchiveCharacterIndexEnricher,
+    CnCharacterIndexEnricher,
+    CnDbCharacterIndexSourceProfile,
 )
 from ba_downloader.infrastructure.regions.cn.dump_backend import (
     CnMetadataRecoveryDumpBackend,
@@ -111,7 +109,7 @@ def build_character_index_source_profile(
     context: RuntimeContext,
 ) -> CharacterIndexSourceProfile:
     _ = context
-    return ArchiveCharacterIndexSourceProfile()
+    return CnDbCharacterIndexSourceProfile()
 
 
 def build_character_index_composition_profile(
@@ -120,5 +118,5 @@ def build_character_index_composition_profile(
     _ = context
     return CharacterIndexCompositionProfile(
         romanize_japanese_names=False,
-        enrichers=(CnArchiveCharacterIndexEnricher(),),
+        enrichers=(CnCharacterIndexEnricher(),),
     )

--- a/src/ba_downloader/infrastructure/tools/cn_metadata_recovery/algorithms/codegen_registration.py
+++ b/src/ba_downloader/infrastructure/tools/cn_metadata_recovery/algorithms/codegen_registration.py
@@ -14,31 +14,34 @@ STANDARD_HEADER_ORDER_V27_2 = HEADER_V27_2
 
 CODE_REG_STRUCT_QWORDS_V27_2 = 15
 CODEGEN_MODULE_QWORDS_V27_2 = 18
-MANUAL_NAME_BY_CODEGEN_INDEX = {
-    # These entries have protected moduleName strings in the current CN metadata recovery sample.
-    # The mapping is resolved by method-pointer count plus surrounding clear names
-    # in the real codegen module pointer list.
-    0: "Animancer.dll",
-    1: "Animancer.FSM.dll",
-    2: "Antlr3.Runtime.dll",
-    3: "AutoMapper.dll",
-    8: "BlueArchive.System.dll",
-    10: "CommunityToolkit.HighPerformance.dll",
-    22: "MX.Shader.dll",
-    23: "MackySoft.SerializeReferenceExtensions.dll",
-    31: "System.dll",
-    36: "System.IO.Compression.dll",
-    46: "UnityEngine.AnimationModule.dll",
-    54: "UnityEngine.InputLegacyModule.dll",
-    63: "UnityEngine.SubsystemsModule.dll",
-    65: "UnityEngine.TextRenderingModule.dll",
-    67: "UnityEngine.UI.dll",
-    73: "UnityEngine.VideoModule.dll",
-    82: "Unity.Notifications.Android.dll",
-    86: "Unity.RenderPipelines.Universal.Runtime.dll",
-    88: "Unity.Timeline.dll",
-    90: "ZString.dll",
-    97: "spine-unity.dll",
+MANUAL_NAMES_BY_CODEGEN_INDEX = {
+    # These entries have protected or misleading moduleName strings in CN samples.
+    # Treat them as candidates only: a name is accepted only when its metadata
+    # method count matches the codegen module's methodPointerCount.
+    0: ["Animancer.dll"],
+    1: ["Animancer.FSM.dll"],
+    2: ["Antlr3.Runtime.dll"],
+    3: ["AutoMapper.dll"],
+    8: ["BlueArchive.System.dll"],
+    10: ["CommunityToolkit.HighPerformance.dll"],
+    21: ["MX.Shader.dll"],
+    22: ["MX.Shader.dll"],
+    23: ["MackySoft.SerializeReferenceExtensions.dll"],
+    31: ["System.dll"],
+    36: ["System.IO.Compression.dll", "System.Numerics.dll"],
+    46: ["UnityEngine.AnimationModule.dll", "UnityEngine.AIModule.dll"],
+    48: ["UnityEngine.AnimationModule.dll"],
+    54: ["UnityEngine.InputLegacyModule.dll"],
+    55: ["UnityEngine.ImageConversionModule.dll"],
+    63: ["UnityEngine.SubsystemsModule.dll"],
+    65: ["UnityEngine.TextRenderingModule.dll"],
+    67: ["UnityEngine.UI.dll"],
+    73: ["UnityEngine.VideoModule.dll"],
+    82: ["Unity.Notifications.Android.dll"],
+    86: ["Unity.RenderPipelines.Universal.Runtime.dll"],
+    88: ["Unity.Timeline.dll"],
+    90: ["ZString.dll", "Unity.RenderPipelines.Core.Runtime.dll"],
+    97: ["spine-unity.dll"],
 }
 
 
@@ -401,25 +404,69 @@ def resolve_module_names(
     modules: list[dict[str, Any]], metadata: StandardMetadata
 ) -> list[dict[str, Any]]:
     names_by_count: dict[int, list[str]] = {}
+    count_by_name: dict[str, int] = {}
     for image, method_count in zip(
         metadata.images,
         metadata.image_method_counts,
         strict=True,
     ):
-        names_by_count.setdefault(method_count, []).append(image["name"])
+        image_name = str(image["name"])
+        names_by_count.setdefault(method_count, []).append(image_name)
+        count_by_name[image_name] = method_count
 
-    used = {module["decoded_name"] for module in modules if module["decoded_name"]}
+    used: set[str] = set()
+
+    def assign(module: dict[str, Any], name: str | None, resolution: str) -> bool:
+        if not name:
+            return False
+        expected_count = count_by_name.get(name)
+        actual_count = int(module["methodPointerCount"])
+        if expected_count is None:
+            module.setdefault("rejected_names", []).append(
+                {
+                    "name": name,
+                    "resolution": resolution,
+                    "reason": "not_in_metadata",
+                }
+            )
+            return False
+        if expected_count != actual_count:
+            module.setdefault("rejected_names", []).append(
+                {
+                    "name": name,
+                    "resolution": resolution,
+                    "reason": "method_count_mismatch",
+                    "metadata_method_count": expected_count,
+                    "module_methodPointerCount": actual_count,
+                }
+            )
+            return False
+        if name in used:
+            module.setdefault("rejected_names", []).append(
+                {
+                    "name": name,
+                    "resolution": resolution,
+                    "reason": "duplicate_name",
+                }
+            )
+            return False
+        module["resolved_name"] = name
+        module["resolution"] = resolution
+        used.add(name)
+        return True
+
     for module in modules:
-        if module["decoded_name"]:
-            module["resolved_name"] = module["decoded_name"]
-            module["resolution"] = module["name_mode"]
+        if assign(module, module["decoded_name"], module["name_mode"]):
             continue
 
-        manual = MANUAL_NAME_BY_CODEGEN_INDEX.get(module["codegen_index"])
-        if manual:
-            module["resolved_name"] = manual
-            module["resolution"] = "manual_index_count_context"
-            used.add(manual)
+    for module in modules:
+        if module.get("resolved_name"):
+            continue
+
+        for manual in MANUAL_NAMES_BY_CODEGEN_INDEX.get(module["codegen_index"], []):
+            if assign(module, manual, "manual_index_count_context"):
+                break
+        if module.get("resolved_name"):
             continue
 
         candidates = [
@@ -462,25 +509,26 @@ def _build_report_from_metadata(
     resolved_order = [module["resolved_name"] for module in modules]
     unresolved = [module for module in modules if not module["resolved_name"]]
     count_mismatches = []
-    if not unresolved:
-        count_by_name = {
-            image["name"]: count
-            for image, count in zip(
-                metadata.images,
-                metadata.image_method_counts,
-                strict=True,
+    count_by_name = {
+        str(image["name"]): count
+        for image, count in zip(
+            metadata.images,
+            metadata.image_method_counts,
+            strict=True,
+        )
+    }
+    for module in modules:
+        if not module["resolved_name"]:
+            continue
+        expected = count_by_name[module["resolved_name"]]
+        if expected != module["methodPointerCount"]:
+            count_mismatches.append(
+                {
+                    "name": module["resolved_name"],
+                    "metadata_method_count": expected,
+                    "module_methodPointerCount": module["methodPointerCount"],
+                }
             )
-        }
-        for module in modules:
-            expected = count_by_name[module["resolved_name"]]
-            if expected != module["methodPointerCount"]:
-                count_mismatches.append(
-                    {
-                        "name": module["resolved_name"],
-                        "metadata_method_count": expected,
-                        "module_methodPointerCount": module["methodPointerCount"],
-                    }
-                )
 
     code_reg_offset = elf_image.va_to_offset(code_reg_va)
     if code_reg_offset is None:

--- a/src/ba_downloader/infrastructure/tools/cn_metadata_recovery/algorithms/parameters.py
+++ b/src/ba_downloader/infrastructure/tools/cn_metadata_recovery/algorithms/parameters.py
@@ -8,7 +8,7 @@ from typing import Any, Protocol
 
 from .attribute_blob import BinaryTypes, MetadataTypeInfo, parse_attribute_blob
 from .codegen_registration import RelocatedElf
-from .standard_metadata import Section, section_map
+from .standard_metadata import Section, i32, section_map
 from .standardize import CUSTOM_SECTIONS
 
 CN_ATTRIBUTE_BLOB_START = 0x870
@@ -141,7 +141,7 @@ def resolve_exported_type_definitions_offset(
     for index in range(image_ranges.size // 0x28):
         row_offset = image_ranges.offset + index * 0x28
         values = struct.unpack_from("<10I", restored_metadata, row_offset)
-        start = struct.unpack("<i", struct.pack("<I", values[4]))[0]
+        start = i32(values[4])
         count = values[5]
         if count:
             if start < 0:
@@ -161,6 +161,37 @@ def resolve_exported_type_definitions_offset(
             f"table=0x{table_size:X} tail=0x{tail_size:X}"
         )
     return tail_size - table_size
+
+
+def resolve_attribute_blob_start(restored_metadata: bytes, tail_offset: int) -> int:
+    if tail_offset < 0 or tail_offset > len(restored_metadata):
+        raise ValueError(f"hidden tail offset is outside metadata: 0x{tail_offset:X}")
+
+    assembly_summary = _read_custom_section(
+        restored_metadata,
+        CUSTOM_SECTIONS["assemblySummary"],
+    )
+    max_end = 0
+    for index in range(assembly_summary.size // 0x40):
+        row_offset = assembly_summary.offset + index * 0x40
+        values = struct.unpack_from("<16I", restored_metadata, row_offset)
+        start = i32(values[2])
+        count = values[3]
+        if count:
+            if start < 0:
+                raise ValueError(
+                    f"assembly {index} referenced assembly range has negative start: {start}"
+                )
+            max_end = max(max_end, start + count)
+
+    blob_start = max_end * 4
+    tail_size = len(restored_metadata) - tail_offset
+    if blob_start >= tail_size:
+        raise ValueError(
+            f"resolved CN attribute blob start is outside hidden tail: "
+            f"blob_start=0x{blob_start:X} tail_size=0x{tail_size:X}"
+        )
+    return blob_start
 
 
 def _sample_type_indices(type_count: int, type_definition_count: int) -> list[int]:
@@ -357,10 +388,12 @@ def resolve_cn_metadata_recovery_parameters(
         restored_metadata,
         tail_offset,
     )
+    blob_start = resolve_attribute_blob_start(restored_metadata, tail_offset)
     parameters = CnMetadataRecoveryParameters(
         tail_offset=tail_offset,
         metadata_registration_va=metadata_registration_va,
         exported_types_offset=exported_types_offset,
+        blob_start=blob_start,
     )
     _validate_attribute_blob_start(
         restored_metadata,

--- a/src/ba_downloader/infrastructure/tools/cn_metadata_recovery/algorithms/standard_metadata.py
+++ b/src/ba_downloader/infrastructure/tools/cn_metadata_recovery/algorithms/standard_metadata.py
@@ -122,7 +122,7 @@ ROW_SIZES = {
     "methods": 0x20,
     "parameterDefaultValues": 0x0C,
     "fieldDefaultValues": 0x0C,
-    "fieldMarshaledSizes": 8,
+    "fieldMarshaledSizes": 0x0C,
     "parameters": 0x0C,
     "fields": 0x0C,
     "genericParameters": 0x10,

--- a/tests/test_character_index.py
+++ b/tests/test_character_index.py
@@ -28,6 +28,9 @@ from ba_downloader.infrastructure.extraction.table.models import ProcessedTableA
 from ba_downloader.infrastructure.regions.archive_character_index import (
     ArchiveCharacterIndexSourceProfile,
 )
+from ba_downloader.infrastructure.regions.cn.character_index import (
+    CnDbCharacterIndexSourceProfile,
+)
 from ba_downloader.infrastructure.regions.jp.character_index import (
     JpDbCharacterIndexSourceProfile,
 )
@@ -157,56 +160,131 @@ def _compose_index_entries(
     )
 
 
-def test_cn_index_sources_warn_but_continue_when_profile_bytes_missing(
+def test_cn_index_sources_read_excel_db_schemas_without_archive_zip(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
     logger = RecordingLogger()
     context = _build_context(tmp_path, region="cn")
-    loader = CharacterIndexSourceLoader(FakeTableSource(tmp_path), logger)
-
-    monkeypatch.setattr(
-        loader,
-        "extract_scenario_db",
-        lambda: [{"Bytes": {"NameJP": "Arona", "SmallPortrait": "Portrait_Arona"}}],
+    table_source = FakeTableSource(
+        tmp_path,
+        {
+            "ScenarioCharacterNameDBSchema": [
+                {
+                    "CharacterName": 1001,
+                    "NameKR": "阿洛娜",
+                    "SmallPortrait": "Portrait_Arona",
+                }
+            ],
+            "CharacterDBSchema": [
+                {
+                    "Id": 1001,
+                    "DevName": "Arona",
+                    "School": "SCHALE",
+                    "Club": "System",
+                }
+            ],
+            "LocalizeCharProfileDBSchema": [
+                {
+                    "CharacterId": 1001,
+                    "FullNameKr": "阿洛娜",
+                    "CharacterVoiceKr": "Kohara Konomi",
+                    "CharacterAgeKr": "16",
+                    "CharHeightKr": "152cm",
+                    "BirthDay": "1/1",
+                    "IllustratorNameKr": "DoReMi",
+                }
+            ],
+            "CostumeDBSchema": [
+                {
+                    "CostumeGroupId": 1001,
+                    "DevName": "Arona_default",
+                    "TextureDir": "Student_Portrait_Arona",
+                }
+            ],
+            "ShopRecruitDBSchema": [{"Id": 100, "InfoCharacterId": [1001]}],
+            "LocalizeGachaShopDBSchema": [
+                {"GachaShopId": 100, "SubTitleKr": "【特别】阿洛娜招募概率提升!"}
+            ],
+        },
     )
+    loader = CharacterIndexSourceLoader(table_source, logger)
     monkeypatch.setattr(
         loader,
         "extract_excel_bytes_files",
-        lambda: {
-            "characterexceltable.bytes": tmp_path / "characterexceltable.bytes",
-        },
-    )
-    monkeypatch.setattr(
-        loader,
-        "load_excel_payloads",
-        lambda paths: {
-            "characterexceltable.bytes": [{"Id": 1001, "DevName": "Arona"}],
-        },
+        lambda: pytest.fail("CN character index should read ExcelDB schema tables"),
     )
 
     sources = loader.load(
         _service_profile(context.region).character_index_source_profile_factory(context)
     )
 
-    assert sources.scenario_db
-    assert sources.char_excel == [{"Id": 1001, "DevName": "Arona"}]
-    assert logger.by_level("warn") == [
-        "Some character index sources are missing or invalid: localizecharprofileexceltable.bytes. Character index might be incomplete."
+    assert table_source.table_names == [
+        "ScenarioCharacterNameDBSchema",
+        "CharacterDBSchema",
+        "LocalizeCharProfileDBSchema",
+        "CostumeDBSchema",
+        "ShopRecruitDBSchema",
+        "LocalizeGachaShopDBSchema",
     ]
+    assert sources.scenario_db == [
+        {
+            "Bytes": {
+                "CharacterName": 1001,
+                "NameKR": "阿洛娜",
+                "SmallPortrait": "Portrait_Arona",
+            }
+        }
+    ]
+    assert sources.char_excel == [
+        {
+            "Id": 1001,
+            "DevName": "Arona",
+            "School": "SCHALE",
+            "Club": "System",
+        }
+    ]
+    assert sources.char_profile == [
+        {
+            "CharacterId": 1001,
+            "FullNameKr": "阿洛娜",
+            "CharacterVoiceKr": "Kohara Konomi",
+            "CharacterAgeKr": "16",
+            "CharHeightKr": "152cm",
+            "BirthDay": "1/1",
+            "IllustratorNameKr": "DoReMi",
+        }
+    ]
+    assert sources.costume_excel == [
+        {
+            "CostumeGroupId": 1001,
+            "DevName": "Arona_default",
+            "TextureDir": "Student_Portrait_Arona",
+        }
+    ]
+    assert sources.shop_recruit == [{"Id": 100, "InfoCharacterId": [1001]}]
+    assert sources.localize_gacha == [
+        {"GachaShopId": 100, "SubTitleKr": "【特别】阿洛娜招募概率提升!"}
+    ]
+    assert logger.by_level("warn") == []
 
 
-def test_index_source_profile_selects_jp_db_and_archive_sources(
+def test_index_source_profile_selects_region_owned_sources(
     tmp_path: Path,
 ) -> None:
     jp_context = _build_context(tmp_path, region="jp")
     cn_context = _build_context(tmp_path, region="cn")
+    gl_context = _build_context(tmp_path, region="gl")
     assert isinstance(
         _service_profile("jp").character_index_source_profile_factory(jp_context),
         JpDbCharacterIndexSourceProfile,
     )
     assert isinstance(
         _service_profile("cn").character_index_source_profile_factory(cn_context),
+        CnDbCharacterIndexSourceProfile,
+    )
+    assert isinstance(
+        _service_profile("gl").character_index_source_profile_factory(gl_context),
         ArchiveCharacterIndexSourceProfile,
     )
 
@@ -348,30 +426,46 @@ def test_jp_index_extract_excel_fails_when_all_db_sources_are_missing(
         )
 
 
-def test_cn_index_extract_excel_fails_when_all_core_sources_are_missing(
-    monkeypatch: pytest.MonkeyPatch,
+def test_cn_index_sources_warn_with_schema_name_when_source_is_missing(
+    tmp_path: Path,
+) -> None:
+    logger = RecordingLogger()
+    context = _build_context(tmp_path, region="cn")
+    loader = CharacterIndexSourceLoader(
+        FakeTableSource(
+            tmp_path,
+            {
+                "ScenarioCharacterNameDBSchema": [
+                    {
+                        "CharacterName": 1001,
+                        "NameKR": "阿洛娜",
+                        "SmallPortrait": "Portrait_Arona",
+                    }
+                ],
+                "CharacterDBSchema": [{"Id": 1001, "DevName": "Arona"}],
+            },
+        ),
+        logger,
+    )
+
+    sources = loader.load(
+        _service_profile(context.region).character_index_source_profile_factory(context)
+    )
+
+    assert sources.scenario_db
+    assert sources.char_excel == [{"Id": 1001, "DevName": "Arona"}]
+    assert logger.by_level("warn") == [
+        "Some character index sources are missing or invalid: LocalizeCharProfileDBSchema. Character index might be incomplete."
+    ]
+
+
+def test_cn_index_sources_fail_when_all_core_db_sources_are_missing(
     tmp_path: Path,
 ) -> None:
     context = _build_context(tmp_path, region="cn")
     loader = CharacterIndexSourceLoader(
         FakeTableSource(tmp_path),
         RecordingLogger(),
-    )
-
-    monkeypatch.setattr(
-        loader,
-        "extract_scenario_db",
-        lambda: [],
-    )
-    monkeypatch.setattr(
-        loader,
-        "extract_excel_bytes_files",
-        lambda: {},
-    )
-    monkeypatch.setattr(
-        loader,
-        "load_excel_payloads",
-        lambda paths: {},
     )
 
     with pytest.raises(

--- a/tests/test_cn_metadata_recovery_pipeline.py
+++ b/tests/test_cn_metadata_recovery_pipeline.py
@@ -15,12 +15,17 @@ from ba_downloader.infrastructure.tools.cn_metadata_recovery import (
 )
 from ba_downloader.infrastructure.tools.cn_metadata_recovery.algorithms.codegen_registration import (
     LoadSegment,
+    resolve_module_names,
 )
 from ba_downloader.infrastructure.tools.cn_metadata_recovery.algorithms.parameters import (
     CnMetadataRecoveryParameters,
+    resolve_attribute_blob_start,
     resolve_exported_type_definitions_offset,
     resolve_hidden_tail_offset,
     resolve_metadata_registration_va,
+)
+from ba_downloader.infrastructure.tools.cn_metadata_recovery.algorithms.standard_metadata import (
+    ROW_SIZES,
 )
 from ba_downloader.infrastructure.tools.cn_metadata_recovery.algorithms.standardize import (
     CUSTOM_SECTIONS,
@@ -60,6 +65,25 @@ class FakeRelocatedElf:
 
     def read_u64_offset(self, offset: int) -> int:
         return struct.unpack_from("<Q", self.data, offset)[0]
+
+
+class FakeCodegenMetadata:
+    def __init__(self, counts_by_name: dict[str, int]) -> None:
+        self.images = [{"name": name} for name in counts_by_name]
+        self.image_method_counts = list(counts_by_name.values())
+
+
+def _fake_codegen_module(
+    index: int,
+    method_count: int,
+    decoded_name: str | None = None,
+) -> dict[str, object]:
+    return {
+        "codegen_index": index,
+        "decoded_name": decoded_name,
+        "name_mode": "plain" if decoded_name else "unresolved",
+        "methodPointerCount": method_count,
+    }
 
 
 def _metadata_with_custom_sections(
@@ -160,6 +184,57 @@ def test_cn_metadata_recovery_resolves_exported_type_offset_from_tail_end() -> N
     )
 
 
+def test_cn_metadata_recovery_resolves_attribute_blob_start_from_assembly_summary() -> (
+    None
+):
+    tail_offset = 0x300
+    assembly_summary_offset = 0x180
+    metadata = bytearray(
+        _metadata_with_custom_sections(
+            {
+                CUSTOM_SECTIONS["assemblySummary"]: (assembly_summary_offset, 0xC0),
+            },
+            size=tail_offset + 0x400,
+        )
+    )
+    struct.pack_into(
+        "<16I",
+        metadata,
+        assembly_summary_offset,
+        0,
+        0,
+        0,
+        2,
+        *([0] * 12),
+    )
+    struct.pack_into(
+        "<16I",
+        metadata,
+        assembly_summary_offset + 0x40,
+        0,
+        0,
+        2,
+        5,
+        *([0] * 12),
+    )
+    struct.pack_into(
+        "<16I",
+        metadata,
+        assembly_summary_offset + 0x80,
+        0,
+        0,
+        7,
+        3,
+        *([0] * 12),
+    )
+
+    assert resolve_attribute_blob_start(bytes(metadata), tail_offset) == 0x28
+
+
+def test_cn_metadata_recovery_uses_twelve_byte_field_marshaled_size_rows() -> None:
+    assert ROW_SIZES["fieldMarshaledSizes"] == 0x0C
+
+
 def test_cn_metadata_recovery_scans_metadata_registration_va() -> None:
     data = bytearray(0x2000)
     _pack_metadata_registration(data, 0x100, type_count=2, type_ptrs_va=0x1400)
@@ -201,6 +276,48 @@ def test_cn_metadata_recovery_metadata_registration_scan_rejects_ambiguous_candi
 
     with pytest.raises(ValueError, match="ambiguous"):
         resolve_metadata_registration_va(FakeRelocatedElf(bytes(data)), 6)
+
+
+def test_cn_metadata_recovery_rejects_stale_manual_codegen_module_name() -> None:
+    metadata = FakeCodegenMetadata(
+        {
+            "System.IO.Compression.dll": 31,
+            "System.Numerics.dll": 200,
+        }
+    )
+    modules = [_fake_codegen_module(36, 200)]
+
+    resolved = resolve_module_names(modules, metadata)  # type: ignore[arg-type]
+
+    assert resolved[0]["resolved_name"] == "System.Numerics.dll"
+    assert {
+        "name": "System.IO.Compression.dll",
+        "resolution": "manual_index_count_context",
+        "reason": "method_count_mismatch",
+        "metadata_method_count": 31,
+        "module_methodPointerCount": 200,
+    } in resolved[0]["rejected_names"]
+
+
+def test_cn_metadata_recovery_resolves_cn_3_0_2_ambiguous_codegen_modules() -> None:
+    metadata = FakeCodegenMetadata(
+        {
+            "MX.Shader.dll": 3,
+            "UnityEngine.ImageConversionModule.dll": 3,
+            "__Generated": 3,
+        }
+    )
+    modules = [
+        _fake_codegen_module(21, 3),
+        _fake_codegen_module(55, 3),
+        _fake_codegen_module(96, 3, "__Generated"),
+    ]
+
+    resolved = resolve_module_names(modules, metadata)  # type: ignore[arg-type]
+
+    assert resolved[0]["resolved_name"] == "MX.Shader.dll"
+    assert resolved[1]["resolved_name"] == "UnityEngine.ImageConversionModule.dll"
+    assert resolved[2]["resolved_name"] == "__Generated"
 
 
 def test_cn_metadata_recovery_pipeline_runs_steps_in_memory(tmp_path: Path) -> None:

--- a/tests/test_dump_backend.py
+++ b/tests/test_dump_backend.py
@@ -584,6 +584,7 @@ def test_cn_metadata_recovery_backend_runs_pipeline_and_writes_only_final_metada
 
     assert logger.warn_messages == []
     assert logger.info_messages == [
+        "Starting CN metadata recovery.",
         "Recovered CN metadata successfully.",
         "Dumped CN metadata recovery il2cpp binary file successfully.",
     ]

--- a/uv.lock
+++ b/uv.lock
@@ -127,7 +127,7 @@ wheels = [
 
 [[package]]
 name = "ba-downloader"
-version = "2.2.0"
+version = "2.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "curl-cffi" },


### PR DESCRIPTION
## Summary

- Update CN CharacterIndex source selection to use current ExcelDB schema tables instead of stale Excel.zip bytes source names.
- Carry dynamic CN metadata recovery fixes for codegen module resolution, attribute blob start, and metadata row-size validation.
- Rename `agents.md` to `AGENTS.md` and trim outdated README wording.

## Why

CN CharacterIndex could warn about missing `characterexceltable.bytes` and `localizecharprofileexceltable.bytes` even when the current CN table data was already available through ExcelDB. CN metadata recovery also needed sample-drift fixes so dynamic parameters are resolved from the active runtime instead of stale assumptions.

## Impact

- CN CharacterIndex builds from `ScenarioCharacterNameDBSchema`, `CharacterDBSchema`, and `LocalizeCharProfileDBSchema`.
- Optional CN enrichment reads `CostumeDBSchema`, `ShopRecruitDBSchema`, and `LocalizeGachaShopDBSchema` when available.
- CN metadata recovery logs when it starts and keeps existing dump output contracts.
- GL and JP source profile behavior is unchanged.

## Validation

- `uv run pytest tests/test_character_index.py tests/test_dump_backend.py tests/test_cn_metadata_recovery_pipeline.py -q`
- `uv run black --check src tests`
- `uv run ruff check src tests`
- `uv run mypy`
- `git diff --check --cached`
